### PR TITLE
fix text string on windows aarch64 msi installer

### DIFF
--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -5,10 +5,14 @@
     <?define ProgramFilesFolder="ProgramFilesFolder" ?>
     <?define Win64="no" ?>
     <?define Arch="(x86)" ?>
-  <?else?>
+  <?elseif $(env.Platform)=x64?>
     <?define ProgramFilesFolder="ProgramFiles64Folder" ?>
     <?define Win64="yes" ?>
     <?define Arch="(x64)" ?>
+  <?elseif $(env.Platform)=arm64?>
+    <?define ProgramFilesFolder="ProgramFilesARMFolder" ?>
+    <?define Win64="no" ?>
+    <?define Arch="(arm64)" ?>
   <?endif?>
 
   <?define ProductVersion="$(var.MSIProductVersion)" ?>


### PR DESCRIPTION
the current windows aarch64 msi installer displays incorrect architecture information:

![image](https://user-images.githubusercontent.com/53073448/113920336-7e519b80-9799-11eb-9701-93661c713ef4.png)

this PR will add some checks on the architecture and display the correct architecture information.

