### PR TITLE
add Name element to Component tree

### DIFF
--- a/wix/Main.dragonwell.wxs.template
+++ b/wix/Main.dragonwell.wxs.template
@@ -221,8 +221,8 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-GPLv2+CE.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="$(var.SetupResourcesDir)\wix-dialog.bmp" />
     <WixVariable Id="WixUIBannerBmp" Value="$(var.SetupResourcesDir)\wix-banner.bmp" />
-    <UI Id="tree" Title="Tree">
-      <UIRef Id="WixUI_FeatureTree" />
+    <UI Id="tree">
+      <UIRef Id="WixUI_FeatureTree" Title="FeatureTree"/>
     </UI>
   </Product>
 </Wix>

--- a/wix/Main.dragonwell.wxs.template
+++ b/wix/Main.dragonwell.wxs.template
@@ -221,7 +221,7 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-GPLv2+CE.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="$(var.SetupResourcesDir)\wix-dialog.bmp" />
     <WixVariable Id="WixUIBannerBmp" Value="$(var.SetupResourcesDir)\wix-banner.bmp" />
-    <UI>
+    <UI Id="tree" Title="Tree">
       <UIRef Id="WixUI_FeatureTree" />
     </UI>
   </Product>

--- a/wix/Main.hotspot.wxs.template
+++ b/wix/Main.hotspot.wxs.template
@@ -225,7 +225,7 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-GPLv2+CE.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="{vendor_branding_dialog}" />
     <WixVariable Id="WixUIBannerBmp" Value="{vendor_branding_banner}" />
-    <UI>
+    <UI Id="tree" Title="Tree">
       <UIRef Id="WixUI_FeatureTree" />
     </UI>
   </Product>

--- a/wix/Main.hotspot.wxs.template
+++ b/wix/Main.hotspot.wxs.template
@@ -225,8 +225,8 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-GPLv2+CE.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="{vendor_branding_dialog}" />
     <WixVariable Id="WixUIBannerBmp" Value="{vendor_branding_banner}" />
-    <UI Id="tree" Title="Tree">
-      <UIRef Id="WixUI_FeatureTree" />
+    <UI Id="tree">
+      <UIRef Id="WixUI_FeatureTree" Title="FeatureTree"/>
     </UI>
   </Product>
 </Wix>

--- a/wix/Main.openj9.wxs.template
+++ b/wix/Main.openj9.wxs.template
@@ -225,7 +225,7 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-OpenJ9.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="{vendor_branding_dialog}" />
     <WixVariable Id="WixUIBannerBmp" Value="{vendor_branding_banner}" />
-    <UI>
+    <UI Id="tree" Title="Tree">
       <UIRef Id="WixUI_FeatureTree" />
     </UI>
   </Product>

--- a/wix/Main.openj9.wxs.template
+++ b/wix/Main.openj9.wxs.template
@@ -225,8 +225,8 @@
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SetupResourcesDir)\license-OpenJ9.en-us.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="{vendor_branding_dialog}" />
     <WixVariable Id="WixUIBannerBmp" Value="{vendor_branding_banner}" />
-    <UI Id="tree" Title="Tree">
-      <UIRef Id="WixUI_FeatureTree" />
+    <UI Id="tree">
+      <UIRef Id="WixUI_FeatureTree" Title="FeatureTree"/>
     </UI>
   </Product>
 </Wix>


### PR DESCRIPTION
I ran our windows installers through [Accessibility Insights](https://accessibilityinsights.io/en/) and it reported that we should include a Name element for all of the components in the tree.