### PR TITLE
reg key CurrentVersion not writted with jdk8 #329

### DIFF
--- a/wix/Main.wxs.template
+++ b/wix/Main.wxs.template
@@ -136,7 +136,7 @@
         <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\{vendor}.jarfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaw.exe&quot; -jar &quot;%1&quot; %*" KeyPath="no" />
       </Component>
       <Component Id="SetOracleJavaSoftKeysCurrentVersion" Guid="*">
-          <Condition><![CDATA[JAVASOFT_CURRENTVERSION <> "1.8" AND JAVASOFT_CURRENTVERSION < $(var.ProductMajorVersion)]]></Condition>
+          <Condition><![CDATA[NOT JAVASOFT_CURRENTVERSION OR JAVASOFT_CURRENTVERSION <> "1.8" AND JAVASOFT_CURRENTVERSION < $(var.ProductMajorVersion)]]></Condition>
           <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]" Name="CurrentVersion" Type="string" Value="[ORACLE_VERSION_KEY]" KeyPath="yes" />
       </Component>
       <Component Id="SetOracleJavaSoftKeys" Guid="*">


### PR DESCRIPTION
The reg key is now added if not already present.
If present and already "1.8" skip recreating.
If present and <> "1.8" check if major version is newer.

All this tests are depended from the base key wich is different for 1.8 and newer and different for JRE vs JDK
><Property Id="ORACLE_JAVASOFT_BASE_KEY" Value="$(var.OracleJavasoftBaseKey)" />
