### PR TITLE
Ensure adoptium-ca-certificates deb file is archived

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -60,7 +60,7 @@ def buildAndTest() {
             break;
     }
     sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
-    archiveArtifacts artifacts: '**/*/build/ospackage/*,**/*/build/reports/**'
+    archiveArtifacts artifacts: '**/*/build/ospackage/*,**/*/build/reports/**,*,**/ospackage/adoptium-ca-certificates*.deb'
 }
 
 def uploadArtifacts() {


### PR DESCRIPTION
The current process does not archive the `adoptium-ca-certificates` package which is a dependency of all the temurin `.deb` packages. This PR resolves that.

Fixes https://github.com/adoptium/installer/issues/363 - an attempt to look at an alternative in https://github.com/adoptium/installer/pull/370 has been abandoned.

Signed-off-by: Stewart X Addison <sxa@redhat.com>