### PR TITLE
add GPG key to rpm build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Build
         run: |
           export _JAVA_OPTIONS="-Xmx4G"
+          export DOCKER_BUILDKIT=1
+          export COMPOSE_DOCKER_CLI_BUILD=1
           ./gradlew --parallel packageJdk${{ matrix.distro }} checkJdk${{ matrix.distro }} -PPRODUCT=${{ matrix.product.name }} -PPRODUCT_VERSION=${{ matrix.product.version }} --stacktrace
 
   # Ensures we don't accept a Gradle Wrapper update that has been tampered with.

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -38,6 +38,8 @@ pipeline {
 
 def setup() {
     cleanWs()
+    // Docker --mount option requires BuildKit
+    env.DOCKER_BUILDKIT=1
     env._JAVA_OPTIONS="-Xmx4g"
     checkout scm
 }
@@ -54,9 +56,10 @@ def buildAndTest() {
     // Install Adoptium GPG key for RPM signing
     withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
         if (DISTRO != "Debian") {
-            SIGN_CMD="-PGPG_KEY=${GPG_KEY}"
+            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} || true")
+        } else {
+            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} || true")
         }
-        sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} ${SIGN_CMD} || true")
     }
     archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
 }

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -4,14 +4,14 @@ pipeline {
     agent {
         label NODE_LABEL
     }
-    tools {
-        jdk "JDK11"
-    }
     stages {
         stage('Linux Installers') {
             matrix {
                 agent {
                     label NODE_LABEL
+                }
+                tools {
+                    jdk "JDK11"
                 }
                 axes {
                     axis {
@@ -38,10 +38,6 @@ pipeline {
 
 def setup() {
     cleanWs()
-    if (PLATFORM == "aarch64") {
-        env.TESTCONTAINERS_RYUK_DISABLED=true
-        env.TESTCONTAINERS_CHECKS_DISABLE=true
-    }
     env._JAVA_OPTIONS="-Xmx4g"
     checkout scm
 }
@@ -55,8 +51,14 @@ def buildAndTest() {
         default: //Adoptium API 
             break;
     }
-    sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
-    archiveArtifacts artifacts: '**/*/build/ospackage/*,**/*/build/reports/**,*,**/ospackage/adoptium-ca-certificates*.deb'
+    // Install Adoptium GPG key for RPM signing
+    withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
+        if (DISTRO != "Debian") {
+            SIGN_CMD="-PGPG_KEY=${GPG_KEY}"
+        }
+        sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} ${SIGN_CMD} || true")
+    }
+    archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
 }
 
 def uploadArtifacts() {

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -40,6 +40,7 @@ def setup() {
     cleanWs()
     // Docker --mount option requires BuildKit
     env.DOCKER_BUILDKIT=1
+    env.COMPOSE_DOCKER_CLI_BUILD=1
     env._JAVA_OPTIONS="-Xmx4g"
     checkout scm
 }

--- a/linuxNew/README.md
+++ b/linuxNew/README.md
@@ -73,6 +73,14 @@ export _JAVA_OPTIONS="-Xmx4g"
 ./gradlew clean packageSuseRedHat checkSuseRedHat --parallel -PPRODUCT=<vendor> -PPRODUCT_VERSION=<version>
 ```
 
+## GPG Signing RPMs
+
+In order to GPG sign the generated RPMs you must add the following argument to the gradlew command:
+
+```shell
+./gradlew packageSuseRedHat -PGPG_KEY=</path/to/private/gpg/key>
+```
+
 ## Building SRPMs and RPMs Directly
 
 If you do not require testing or advanced build support, it is perfectly fine to eschew the Gradle-based build and to

--- a/linuxNew/build.gradle
+++ b/linuxNew/build.gradle
@@ -39,3 +39,7 @@ def getProduct() {
 def getProductVersion() {
 	return hasProperty("PRODUCT_VERSION") ? Integer.parseInt(PRODUCT_VERSION) : null
 }
+
+def getGPGKey() {
+	return hasProperty("GPG_KEY") ? GPG_KEY.toString() : null
+}

--- a/linuxNew/jdk/redhat/build.gradle
+++ b/linuxNew/jdk/redhat/build.gradle
@@ -69,17 +69,22 @@ task packageJdkRedHat {
 			into("${buildDir}/generated/packaging")
 		}
 		if (gpgKey) {
-			project.copy {
-				from("${gpgKey}")
-				into("${buildDir}/private.gpg")
+			project.exec {
+				workingDir "src/main/packaging"
+				commandLine "docker", "build",
+					"-t", "adoptium-packages-linux-jdk-redhat",
+					"--secret", "id=gpg,src=${gpgKey}",
+					"-f", "Dockerfile",
+					getProjectDir().absolutePath + "/src/main/packaging"
 			}
-		}
-		project.exec {
-			workingDir "src/main/packaging"
-			commandLine "docker", "build",
-				"-t", "adoptium-packages-linux-jdk-redhat",
-				"-f", "Dockerfile",
-				getProjectDir().absolutePath + "/src/main/packaging"
+		} else {
+			project.exec {
+				workingDir "src/main/packaging"
+				commandLine "docker", "build",
+					"-t", "adoptium-packages-linux-jdk-redhat",
+					"-f", "Dockerfile",
+					getProjectDir().absolutePath + "/src/main/packaging"
+			}
 		}
 
 		project.exec {

--- a/linuxNew/jdk/redhat/build.gradle
+++ b/linuxNew/jdk/redhat/build.gradle
@@ -54,6 +54,7 @@ task packageJdkRedHat {
 
 	def product = getProduct()
 	def productVersion = getProductVersion()
+	def gpgKey = getGPGKey()
 
 	def outputDir = new File(project.buildDir.absolutePath, "ospackage")
 	outputs.dir(outputDir)
@@ -66,6 +67,12 @@ task packageJdkRedHat {
 		project.copy {
 			from("src/main/packaging/$product/$productVersion/")
 			into("${buildDir}/generated/packaging")
+		}
+		if (gpgKey) {
+			project.copy {
+				from("${gpgKey}")
+				into("${buildDir}/private.gpg")
+			}
 		}
 		project.exec {
 			workingDir "src/main/packaging"

--- a/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
@@ -21,6 +21,16 @@ RUN rm -f /tmp/tini.asc
 RUN groupadd -g 10001 builder
 RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
 
+# Add GPG key
+USER builder
+RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg gpg --import /tmp/private.gpg
+RUN printf '%%_signature gpg\n\
+%%_gpg_name 3B04D753C9050D9A5D343F39843C48A565F8F04B\n\
+%%__gpg /usr/bin/gpg\n\
+'\
+>> /home/builder/.rpmmacros
+USER root
+
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
 RUN printf '#!/usr/bin/env bash\n\
@@ -29,12 +39,9 @@ set -euxo pipefail\n\
 # Ensure necessary directories for rpmbuild operation are present.\n\
 rpmdev-setuptree \n\
 \n\
-# Add GPG key if installed.\n\
-if [[ -f /home/builder/build/private.gpg ]]; then\n\
-	gpg --import /home/builder/build/private.gpg \n\
-	gpg --list-secret-keys --keyid-format LONG \n\
-fi;\n\
-# Build all spec files we can find.\n\
+cat /home/builder/.rpmmacros \n\
+gpg --list-signatures \n\
+# Build all spec files we can fin.\n\
 targets="x86_64 ppc64le s390x" \n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
 	spectool -g -R "$spec";\n\
@@ -47,12 +54,11 @@ for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
 	done;\n\
 done;\n\
 \n\
-
 # Copy generated SRPMS, RPMs to destination folder\n\
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
 # Sign generated RPMs with rpmsign.\n\
-if [[ -f /home/builder/build/private.gpg ]]; then\n\
-	rpmsign /home/builder/out/*.rpm \n\
+if [[ -f /home/builder/.rpmmacros ]]; then \n\
+	rpmsign --addsign /home/builder/out/*.rpm \n\
 fi;\n\
 '\
 >> /home/builder/build.sh

--- a/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:33
 
-RUN dnf update -y && dnf install -y rpmdevtools rpmlint gnupg2 wget tar dpkg findutils
+RUN dnf update -y && dnf install -y rpmdevtools rpm-sign rpmlint gnupg2 wget tar dpkg findutils
 
 RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
@@ -29,8 +29,12 @@ set -euxo pipefail\n\
 # Ensure necessary directories for rpmbuild operation are present.\n\
 rpmdev-setuptree \n\
 \n\
+# Add GPG key if installed.\n\
+if [[ -f /home/builder/build/private.gpg ]]; then\n\
+	gpg --import /home/builder/build/private.gpg \n\
+	gpg --list-secret-keys --keyid-format LONG \n\
+fi;\n\
 # Build all spec files we can find.\n\
-
 targets="x86_64 ppc64le s390x" \n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
 	spectool -g -R "$spec";\n\
@@ -46,6 +50,10 @@ done;\n\
 
 # Copy generated SRPMS, RPMs to destination folder\n\
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
+# Sign generated RPMs with rpmsign.\n\
+if [[ -f /home/builder/build/private.gpg ]]; then\n\
+	rpmsign /home/builder/out/*.rpm \n\
+fi;\n\
 '\
 >> /home/builder/build.sh
 RUN chmod +x /home/builder/build.sh

--- a/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/redhat/src/main/packaging/Dockerfile
@@ -23,12 +23,15 @@ RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Add GPG key
 USER builder
-RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg gpg --import /tmp/private.gpg
-RUN printf '%%_signature gpg\n\
+RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg \
+	if [[ -f /tmp/private.gpg ]]; then \
+		gpg --import /tmp/private.gpg; \
+		printf '%%_signature gpg\n\
 %%_gpg_name 3B04D753C9050D9A5D343F39843C48A565F8F04B\n\
 %%__gpg /usr/bin/gpg\n\
 '\
->> /home/builder/.rpmmacros
+>> /home/builder/.rpmmacros; \
+	fi
 USER root
 
 # Prepare entrypoint and build scripts
@@ -39,8 +42,6 @@ set -euxo pipefail\n\
 # Ensure necessary directories for rpmbuild operation are present.\n\
 rpmdev-setuptree \n\
 \n\
-cat /home/builder/.rpmmacros \n\
-gpg --list-signatures \n\
 # Build all spec files we can fin.\n\
 targets="x86_64 ppc64le s390x" \n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
@@ -57,7 +58,7 @@ done;\n\
 # Copy generated SRPMS, RPMs to destination folder\n\
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
 # Sign generated RPMs with rpmsign.\n\
-if [[ -f /home/builder/.rpmmacros ]]; then \n\
+if grep -q %%_gpg_name /home/builder/.rpmmacros; then \n\
 	rpmsign --addsign /home/builder/out/*.rpm \n\
 fi;\n\
 '\

--- a/linuxNew/jdk/redhat/src/main/packaging/entrypoint.sh
+++ b/linuxNew/jdk/redhat/src/main/packaging/entrypoint.sh
@@ -5,6 +5,8 @@ set -euox pipefail
 # into it without changing its ownership (which could render the folder or its contents inaccessible to the host user),
 # add the user builder to the group with the same GID as the host user.
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
+# gpg: signing failed: Inappropriate ioctl for device
+export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
 chmod g+w /home/builder/out

--- a/linuxNew/jdk/redhat/src/main/packaging/entrypoint.sh
+++ b/linuxNew/jdk/redhat/src/main/packaging/entrypoint.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 # into it without changing its ownership (which could render the folder or its contents inaccessible to the host user),
 # add the user builder to the group with the same GID as the host user.
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
-# gpg: signing failed: Inappropriate ioctl for device
+# The command below fixes gpg: signing failed: Inappropriate ioctl for device
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -242,5 +242,5 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Fri Aug 31 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.302.0.0.8-1.adopt0
+* Tue Aug 31 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.302.0.0.8-1.adopt0
 - Eclipse Temurin 8.0.302-b08 release.

--- a/linuxNew/jdk/suse/build.gradle
+++ b/linuxNew/jdk/suse/build.gradle
@@ -57,6 +57,7 @@ task packageJdkSuse {
 
 	def product = getProduct()
 	def productVersion = getProductVersion()
+	def gpgKey = getGPGKey()
 
 	doLast {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
@@ -67,13 +68,25 @@ task packageJdkSuse {
 			from("src/main/packaging/$product/$productVersion/")
 			into("${buildDir}/generated/packaging")
 		}
-		project.exec {
-			workingDir "src/main/packaging"
-			commandLine "docker", "build",
-				"-t", "adoptium-packages-linux-jdk-suse",
-				"-f", "Dockerfile",
-				getProjectDir().absolutePath + "/src/main/packaging"
+		if (gpgKey) {
+			project.exec {
+				workingDir "src/main/packaging"
+				commandLine "docker", "build",
+					"-t", "adoptium-packages-linux-jdk-suse",
+					"--secret", "id=gpg,src=${gpgKey}",
+					"-f", "Dockerfile",
+					getProjectDir().absolutePath + "/src/main/packaging"
+			}
+		} else {
+			project.exec {
+				workingDir "src/main/packaging"
+				commandLine "docker", "build",
+					"-t", "adoptium-packages-linux-jdk-suse",
+					"-f", "Dockerfile",
+					getProjectDir().absolutePath + "/src/main/packaging"
+			}			
 		}
+
 
 		project.exec {
 			workingDir getRootDir()

--- a/linuxNew/jdk/suse/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/suse/src/main/packaging/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.2
 
-RUN zypper update -y && zypper install -y rpm-build rpm-sign rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
+RUN zypper update -y && zypper install -y rpm-build rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
 
 RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc

--- a/linuxNew/jdk/suse/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/suse/src/main/packaging/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.2
 
-RUN zypper update -y && zypper install -y rpm-build rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
+RUN zypper update -y && zypper install -y rpm-build rpm-sign rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
 
 RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
@@ -14,6 +14,16 @@ RUN rm -f /tmp/gosu.asc
 RUN groupadd -g 10001 builder
 RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
 
+# Add GPG key
+USER builder
+RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg gpg --import /tmp/private.gpg
+RUN printf '%%_signature gpg\n\
+%%_gpg_name 3B04D753C9050D9A5D343F39843C48A565F8F04B\n\
+%%__gpg /usr/bin/gpg\n\
+'\
+>> /home/builder/.rpmmacros
+USER root
+
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
 RUN printf '#!/usr/bin/env bash\n\
@@ -22,6 +32,8 @@ set -euxo pipefail\n\
 # Ensure necessary directories for rpmbuild operation are present.\n\
 rpmdev-setuptree \n\
 \n\
+cat /home/builder/.rpmmacros \n\
+gpg --list-signatures \n\
 # Build all spec files we can find.\n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
 	rpmbuild --undefine=_disable_source_fetch -bb "$spec";\n\
@@ -29,6 +41,10 @@ done;\n\
 \n\
 # Copy generated RPMs to destination folder\n\
 find /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
+# Sign generated RPMs with rpmsign.\n\
+if [[ -f /home/builder/.rpmmacros ]]; then \n\
+	rpmsign --addsign /home/builder/out/*.rpm \n\
+fi;\n\
 '\
 >> /home/builder/build.sh
 RUN chmod +x /home/builder/build.sh

--- a/linuxNew/jdk/suse/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/suse/src/main/packaging/Dockerfile
@@ -16,12 +16,15 @@ RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Add GPG key
 USER builder
-RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg gpg --import /tmp/private.gpg
-RUN printf '%%_signature gpg\n\
+RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg \
+	if [[ -f /tmp/private.gpg ]]; then \
+		gpg --import /tmp/private.gpg; \
+		printf '%%_signature gpg\n\
 %%_gpg_name 3B04D753C9050D9A5D343F39843C48A565F8F04B\n\
 %%__gpg /usr/bin/gpg\n\
 '\
->> /home/builder/.rpmmacros
+>> /home/builder/.rpmmacros; \
+	fi
 USER root
 
 # Prepare entrypoint and build scripts
@@ -32,8 +35,6 @@ set -euxo pipefail\n\
 # Ensure necessary directories for rpmbuild operation are present.\n\
 rpmdev-setuptree \n\
 \n\
-cat /home/builder/.rpmmacros \n\
-gpg --list-signatures \n\
 # Build all spec files we can find.\n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
 	rpmbuild --undefine=_disable_source_fetch -bb "$spec";\n\
@@ -42,7 +43,7 @@ done;\n\
 # Copy generated RPMs to destination folder\n\
 find /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
 # Sign generated RPMs with rpmsign.\n\
-if [[ -f /home/builder/.rpmmacros ]]; then \n\
+if grep -q %%_gpg_name /home/builder/.rpmmacros; then \n\
 	rpmsign --addsign /home/builder/out/*.rpm \n\
 fi;\n\
 '\

--- a/linuxNew/jdk/suse/src/main/packaging/entrypoint.sh
+++ b/linuxNew/jdk/suse/src/main/packaging/entrypoint.sh
@@ -5,6 +5,8 @@ set -euox pipefail
 # into it without changing its ownership (which could render the folder or its contents inaccessible to the host user),
 # add the user builder to the group with the same GID as the host user.
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
+# gpg: signing failed: Inappropriate ioctl for device
+export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
 chmod g+w /home/builder/out

--- a/linuxNew/jdk/suse/src/main/packaging/entrypoint.sh
+++ b/linuxNew/jdk/suse/src/main/packaging/entrypoint.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 # into it without changing its ownership (which could render the folder or its contents inaccessible to the host user),
 # add the user builder to the group with the same GID as the host user.
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
-# gpg: signing failed: Inappropriate ioctl for device
+# The command below fixes gpg: signing failed: Inappropriate ioctl for device
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder


### PR DESCRIPTION
This PR add's the ability to pass a private GPG key to the docker environment to allow RPM signing to take place

Tested in https://ci.adoptopenjdk.net/job/gdams-packages-linux-pipeline/16/