### PR TITLE
Ensure adoptium-ca-certificates deb file is archived

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -60,7 +60,7 @@ def buildAndTest() {
             break;
     }
     sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
-    archiveArtifacts artifacts: '**/*/build/ospackage/*,**/*/build/reports/**'
+    archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
 }
 
 def uploadArtifacts() {


### PR DESCRIPTION
The packaging job does not currently archive the `ca-certificates` `.deb` package. This PR resolves that.

Signed-off-by: Stewart X Addison <sxa@redhat.com>