### PR TITLE
Enable target s390x and ppc64le on x86-86 host on SUSE

### DIFF
--- a/linuxNew/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
+++ b/linuxNew/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
@@ -34,7 +34,7 @@ final class RpmFiles {
 	}
 
 	static Path hostRpmPath() {
-		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.rpm");
+		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.x86_64.rpm");
 	}
 
 	private static Path findBuildOutputOnHost(String pattern) {

--- a/linuxNew/jdk/suse/src/main/packaging/Dockerfile
+++ b/linuxNew/jdk/suse/src/main/packaging/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.2
 
-RUN zypper update -y && zypper install -y rpm-build rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
+RUN zypper update -y && zypper install -y rpm-build rpm-devel rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
 
 RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
@@ -23,12 +23,21 @@ set -euxo pipefail\n\
 rpmdev-setuptree \n\
 \n\
 # Build all spec files we can find.\n\
+
+targets="x86_64 ppc64le s390x" \n\
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
-	rpmbuild --undefine=_disable_source_fetch -bb "$spec";\n\
+	rpmdev-spectool -g -R "$spec";\n\
+	rpmbuild --nodeps -bs "$spec"; \n\
+	if [[ "$spec" =~ "temurin-8-jdk" ]]; then \n\
+		targets="x86_64 ppc64le" \n\
+	fi \n\
+	for target in $targets; do \n\
+		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;\n\
+	done;\n\
 done;\n\
 \n\
 # Copy generated RPMs to destination folder\n\
-find /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
+find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
 '\
 >> /home/builder/build.sh
 RUN chmod +x /home/builder/build.sh

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -15,19 +15,32 @@
 
 # Map architecture to the expected value in the download URL; Allow for a
 # pre-defined value of vers_arch and use that if it's defined
-#  x86_64 => x64
-#  i668 = x86
-%if %{!?vers_arch:1}0
+
 %ifarch x86_64
 %global vers_arch x64
-%else
-%ifarch %{ix86}
-%global vers_arch x86
-%else
-# Catch-all, use _arch value
-%global vers_arch %{_arch}
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 0
+%global sha_src_num 1
 %endif
+%ifarch ppc64le
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 2
+%global sha_src_num 3
 %endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 4
+%global sha_src_num 5
+%endif
+# Allow for noarch SRPM build
+%ifarch noarch
+%global src_num 0
+%global sha_src_num 1
 %endif
 
 Name:        temurin-11-jdk
@@ -81,8 +94,15 @@ Provides: jre-11
 Provides: jre-11-%{java_provides}
 Provides: jre-%{java_provides}
 
+# First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Second architecture (ppc64le)
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Third architecture (s390x)
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}
@@ -94,10 +114,10 @@ applications and components using the programming language Java.
 
 %prep
 pushd "%{_sourcedir}"
-sha256sum -c "%SOURCE1"
+sha256sum -c "%{expand:%{SOURCE%{sha_src_num}}}"
 popd
 
-%setup -n jdk-%{upstream_version}
+%setup -n jdk-%{upstream_version} -T -b %{src_num}
 
 %build
 # noop
@@ -105,7 +125,7 @@ popd
 %install
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
-tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{SOURCE0}
+tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
 
 # Strip bundled Freetype and use OS package instead.
 rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -15,19 +15,32 @@
 
 # Map architecture to the expected value in the download URL; Allow for a
 # pre-defined value of vers_arch and use that if it's defined
-#  x86_64 => x64
-#  i668 = x86
-%if %{!?vers_arch:1}0
+
 %ifarch x86_64
 %global vers_arch x64
-%else
-%ifarch %{ix86}
-%global vers_arch x86
-%else
-# Catch-all, use _arch value
-%global vers_arch %{_arch}
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 0
+%global sha_src_num 1
 %endif
+%ifarch ppc64le
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 2
+%global sha_src_num 3
 %endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global src_num 4
+%global sha_src_num 5
+%endif
+# Allow for noarch SRPM build
+%ifarch noarch
+%global src_num 0
+%global sha_src_num 1
 %endif
 
 Name:        temurin-17-jdk
@@ -81,8 +94,15 @@ Provides: jre-17
 Provides: jre-17-%{java_provides}
 Provides: jre-%{java_provides}
 
+# First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Second architecture (ppc64le)
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Third architecture (s390x)
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}
@@ -94,10 +114,10 @@ applications and components using the programming language Java.
 
 %prep
 pushd "%{_sourcedir}"
-sha256sum -c "%SOURCE1"
+sha256sum -c "%{expand:%{SOURCE%{sha_src_num}}}"
 popd
 
-%setup -n jdk-%{upstream_version}
+%setup -n jdk-%{upstream_version} -T -b %{src_num}
 
 %build
 # noop
@@ -105,7 +125,7 @@ popd
 %install
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
-tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{SOURCE0}
+tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
 
 # Strip bundled Freetype and use OS package instead.
 rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -14,19 +14,24 @@
 
 # Map architecture to the expected value in the download URL; Allow for a
 # pre-defined value of vers_arch and use that if it's defined
-#  x86_64 => x64
-#  i668 = x86
-%if %{!?vers_arch:1}0
+
 %ifarch x86_64
 %global vers_arch x64
-%else
-%ifarch %{ix86}
-%global vers_arch x86
-%else
-# Catch-all, use _arch value
-%global vers_arch %{_arch}
+%global vers_arch2 ppc64le
+%global src_num 0
+%global sha_src_num 1
 %endif
+%ifarch ppc64le
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global src_num 2
+%global sha_src_num 3
 %endif
+
+# Allow for noarch SRPM build
+%ifarch noarch
+%global src_num 0
+%global sha_src_num 1
 %endif
 
 Name:        temurin-8-jdk
@@ -80,8 +85,12 @@ Provides: jre-8
 Provides: jre-8-%{java_provides}
 Provides: jre-%{java_provides}
 
+# First architecture (x86_64)
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
 Source1: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
+# Second architecture (ppc64le)
+Source2: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
+Source3: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}
@@ -93,10 +102,10 @@ applications and components using the programming language Java.
 
 %prep
 pushd "%{_sourcedir}"
-sha256sum -c "%SOURCE1"
+sha256sum -c "%{expand:%{SOURCE%{sha_src_num}}}"
 popd
 
-%setup -n jdk%{upstream_version}
+%setup -n jdk%{upstream_version} -T -b %{src_num}
 
 %build
 # noop
@@ -104,7 +113,7 @@ popd
 %install
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
-tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{SOURCE0}
+tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
 
 # Strip bundled Freetype and use OS package instead.
 rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"

--- a/linuxNew/jdk/suse/src/packageTest/java/packaging/RpmFiles.java
+++ b/linuxNew/jdk/suse/src/packageTest/java/packaging/RpmFiles.java
@@ -34,7 +34,7 @@ final class RpmFiles {
 	}
 
 	static Path hostRpmPath() {
-		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.rpm");
+		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.x86_64.rpm");
 	}
 
 	private static Path findBuildOutputOnHost(String pattern) {


### PR DESCRIPTION
Enable target s390x and ppc64le on x86-86 host on SUSE

Enable SRPM and copy SPRM to destination Directory

close #361 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>
