### PR TITLE
Add non-x64 Debian architectures to linuxNew jenkins pipeline

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -5,6 +5,34 @@ pipeline {
         label NODE_LABEL
     }
     stages {
+        stage('Linux-x64 Installers') {
+            matrix {
+                agent {
+                    label NODE_LABEL
+                }
+                tools {
+                    jdk "JDK11"
+                }
+                axes {
+                    axis {
+                        name 'DISTRO'
+                        values 'Debian', 'RedHat', 'Suse'
+                    }
+                }
+                stages {
+                    stage('Build Installer') {
+                        steps {
+                            echo "Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                            setup()
+                            dir('linuxNew') {
+                                buildAndTest()
+                            }
+                            uploadArtifacts()
+                        }
+                    }
+                }
+	    }
+        }
         stage('Run non-x64 Deb packaging in parallel') {
             parallel {
                 stage('aarch64 Debian packages') {
@@ -45,27 +73,12 @@ pipeline {
                         uploadArtifacts()
                     }
                 }
-                stage('armv7l Debian packages') {
-                    agent {
-                        label "docker&&linux&&armv7l"
-                    }
-                    tools {
-                        jdk "JDK11"
-                    }
-                    environment {
-                        DISTRO = "Debian"
-                        JAVA_OPTIONS = "-Xmx2g"
-                    }
-                    steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                        setup()
-                        dir('linuxNew') {
-                            buildNoTest()
-                        }
-                        uploadArtifacts()
-                    }
-                }
                 stage('s390x Debian packages') {
+                    when {
+                       expression {
+                          return VERSION != '8'
+                       }
+                    }
                     agent {
                         label "docker&&linux&&s390x"
                     }
@@ -74,6 +87,7 @@ pipeline {
                     }
                     environment {
                         DISTRO = "Debian"
+                        DOCKER_BUILDKIT = "0"
                     }
                     steps {
                         echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
@@ -85,34 +99,6 @@ pipeline {
                     }
                 }
             }
-        }
-        stage('Linux-x64 Installers') {
-            matrix {
-                agent {
-                    label NODE_LABEL
-                }
-                tools {
-                    jdk "JDK11"
-                }
-                axes {
-                    axis {
-                        name 'DISTRO'
-                        values 'Debian', 'RedHat', 'Suse'
-                    }
-                }
-                stages {
-                    stage('Build Installer') {
-                        steps {
-                            echo "Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                            setup()
-                            dir('linuxNew') {
-                                buildAndTest()
-                            }
-                            uploadArtifacts()
-                        }
-                    }
-                }
-	    }
         }
     }
 }
@@ -130,9 +116,9 @@ def buildAndTest() {
     // Install Adoptium GPG key for RPM signing
     withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
         if (DISTRO != "Debian") {
-            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} || true")
+            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY}")
         } else {
-            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} || true")
+            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
         }
     }
     archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
@@ -142,9 +128,9 @@ def buildNoTest() {
     // Install Adoptium GPG key for RPM signing
     withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
         if (DISTRO != "Debian") {
-            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} || true")
+            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY}")
         } else {
-            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} || true")
+            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
         }
     }
     archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -5,6 +5,87 @@ pipeline {
         label NODE_LABEL
     }
     stages {
+        stage('Run non-x64 Deb packaging in parallel') {
+            parallel {
+                stage('aarch64 Debian packages') {
+                    agent {
+                        label "docker&&linux&&aarch64"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildAndTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('ppc64le Debian packages') {
+                    agent {
+                        label "docker&&linux&&ppc64le"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildAndTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('armv7l Debian packages') {
+                    agent {
+                        label "docker&&linux&&armv7l"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                        JAVA_OPTIONS = "-Xmx2g"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildNoTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('s390x Debian packages') {
+                    agent {
+                        label "docker&&linux&&s390x"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildNoTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+            }
+        }
         stage('Linux-x64 Installers') {
             matrix {
                 agent {
@@ -32,87 +113,6 @@ pipeline {
                     }
                 }
 	    }
-        }
-        stage('Run non-x64 Deb packaging in parallel') {
-            parallel {
-                stage('aarch64 Deb packages') {
-                    agent {
-                        label "docker&&linux&&aarch64"
-                    }
-                    tools {
-                        jdk "JDK11"
-                    }
-                    environment {
-                        DISTRO = "Debian"
-                    }
-                    steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                        setup()
-                        dir('linuxNew') {
-                            buildAndTest()
-                        }
-                        uploadArtifacts()
-                    }
-                }
-                stage('ppc64le packages') {
-                    agent {
-                        label "docker&&linux&&ppc64le"
-                    }
-                    tools {
-                        jdk "JDK11"
-                    }
-                    environment {
-                        DISTRO = "Debian"
-                    }
-                    steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                        setup()
-                        dir('linuxNew') {
-                            buildAndTest()
-                        }
-                        uploadArtifacts()
-                    }
-                }
-                stage('armv7l packages') {
-                    agent {
-                        label "docker&&linux&&armv7l"
-                    }
-                    tools {
-                        jdk "JDK11"
-                    }
-                    environment {
-                        DISTRO = "Debian"
-                        JAVA_OPTIONS = "-Xmx2g"
-                    }
-                    steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                        setup()
-                        dir('linuxNew') {
-                            buildNoTest()
-                        }
-                        uploadArtifacts()
-                    }
-                }
-                stage('s390x packages') {
-                    agent {
-                        label "docker&&linux&&s390x"
-                    }
-                    tools {
-                        jdk "JDK11"
-                    }
-                    environment {
-                        DISTRO = "Debian"
-                    }
-                    steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                        setup()
-                        dir('linuxNew') {
-                            buildNoTest()
-                        }
-                        uploadArtifacts()
-                    }
-                }
-            }
         }
     }
 }

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         label NODE_LABEL
     }
     stages {
-        stage('Linux Installers') {
+        stage('Linux-x64 Installers') {
             matrix {
                 agent {
                     label NODE_LABEL
@@ -31,6 +31,87 @@ pipeline {
                         }
                     }
                 }
+	    }
+        }
+        stage('Run non-x64 Deb packaging in parallel') {
+            parallel {
+                stage('aarch64 Deb packages') {
+                    agent {
+                        label "docker&&linux&&aarch64"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildAndTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('ppc64le packages') {
+                    agent {
+                        label "docker&&linux&&ppc64le"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildAndTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('armv7l packages') {
+                    agent {
+                        label "docker&&linux&&armv7l"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                        JAVA_OPTIONS = "-Xmx2g"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildNoTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
+                stage('s390x packages') {
+                    agent {
+                        label "docker&&linux&&s390x"
+                    }
+                    tools {
+                        jdk "JDK11"
+                    }
+                    environment {
+                        DISTRO = "Debian"
+                    }
+                    steps {
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        setup()
+                        dir('linuxNew') {
+                            buildNoTest()
+                        }
+                        uploadArtifacts()
+                    }
+                }
             }
         }
     }
@@ -46,20 +127,24 @@ def setup() {
 }
 
 def buildAndTest() {
-    switch(JDK_SOURCE) {
-        case "upstream":
-            break;
-        case "customized":
-            break;
-        default: //Adoptium API 
-            break;
-    }
     // Install Adoptium GPG key for RPM signing
     withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
         if (DISTRO != "Debian") {
             sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} || true")
         } else {
             sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} || true")
+        }
+    }
+    archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
+}
+
+def buildNoTest() {
+    // Install Adoptium GPG key for RPM signing
+    withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
+        if (DISTRO != "Debian") {
+            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} || true")
+        } else {
+            sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} || true")
         }
     }
     archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -22,12 +22,14 @@ pipeline {
                 stages {
                     stage('Build Installer') {
                         steps {
-                            echo "Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                            setup()
-                            dir('linuxNew') {
-                                buildAndTest()
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                echo "Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                                setup()
+                                dir('linuxNew') {
+                                    buildAndTest()
+                                }
+                                uploadArtifacts()
                             }
-                            uploadArtifacts()
                         }
                     }
                 }
@@ -46,12 +48,14 @@ pipeline {
                         DISTRO = "Debian"
                     }
                     steps {
+                      catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                         echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO} on aarch64"
                         setup()
                         dir('linuxNew') {
                             buildNoTest()
                         }
                         uploadArtifacts()
+                      }
                     }
                 }
                 stage('ppc64le Debian packages') {

--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -46,10 +46,10 @@ pipeline {
                         DISTRO = "Debian"
                     }
                     steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO} on aarch64"
                         setup()
                         dir('linuxNew') {
-                            buildAndTest()
+                            buildNoTest()
                         }
                         uploadArtifacts()
                     }
@@ -65,10 +65,10 @@ pipeline {
                         DISTRO = "Debian"
                     }
                     steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO} on ppc64le"
                         setup()
                         dir('linuxNew') {
-                            buildAndTest()
+                            buildNoTest()
                         }
                         uploadArtifacts()
                     }
@@ -90,7 +90,7 @@ pipeline {
                         DOCKER_BUILDKIT = "0"
                     }
                     steps {
-                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO}"
+                        echo "Debian Installer Job for Temurin ${VERSION} - ${DISTRO} so s390x"
                         setup()
                         dir('linuxNew') {
                             buildNoTest()

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -7,6 +7,12 @@ amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/down
 amd64_checksum = 3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30
 arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.13_8.tar.gz
 arm64_checksum = a77013bff10a5e9c59159231dd5c4bd071fc4c24beed42bd49b82803ba9506ef
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.13_8.tar.gz
+armhf_checksum = 61ee45c4ef21a85a116a87e1bca2e2a420b3af432be8d801bd52c660ffebaa9f
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.13_8.tar.gz
+ppc64el_checksum = 82f14cda71cff99c878bf8400598a87235adb6c81b0337f7077c27e5cac1190c
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.13_8.tar.gz
+s390x_checksum = 9d280d86fdf6a7d9e5cbf54dc37f1d6d09dfe676ff5c684802fdfa3932eee63e
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -7,6 +7,12 @@ amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/down
 amd64_checksum = 6ea18c276dcbb8522feeebcfc3a4b5cb7c7e7368ba8590d3326c6c3efc5448b6
 arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz
 arm64_checksum = f23d482b2b4ada08166201d1a0e299e3e371fdca5cd7288dcbd81ae82f3a75e3
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz
+armhf_checksum = f5945a39929384235e7cb1c57df071b8c7e49274632e2a54e54b2bad05de21a5
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.1_12.tar.gz
+ppc64el_checksum = bd65d4e8ecc4236924ae34d2075b956799abca594021e1b40c36aa08a0d610b0
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.1_12.tar.gz
+s390x_checksum = dcc17e6ef28984656e997b6b8a6a31c89f45aff87a56b5d3819137c8f1050bef
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -6,8 +6,12 @@ priority = 1081
 jvm_tools = appletviewer clhsdb extcheck hsdb idlj jar jarsigner java javac javadoc javah javap jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc jexec
 amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_x64_linux_hotspot_8u312b07.tar.gz
 amd64_checksum = 699981083983b60a7eeb511ad640fae3ae4b879de5a3980fe837e8ade9c34a08
-#arm64_tarball_url = https://github.com/Adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_aarch64_linux_hotspot_8u312b07.tar.gz
-#arm64_checksum = 87ff502eba3008cac71edeb9595398a73dc14883fe3072d152e731bf0877897e
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_aarch64_linux_hotspot_8u312b07.tar.gz
+arm64_checksum = 87ff502eba3008cac71edeb9595398a73dc14883fe3072d152e731bf0877897e
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_arm_linux_hotspot_8u312b07.tar.gz
+armhf_checksum = 5a9e72c6c20373aa380554a6d7191a258540d2a0399d842223b8d5eb0f74b298
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u312b07.tar.gz
+ppc64el_checksum = ddce3f067eab6fd98bb2a8ea3d18de6b09ea41d10382c76ad22bd3e7895951cf
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm


### PR DESCRIPTION
This isn't great as it's not currently building the original stuff and the stuff that runs on other machines in parallel, and I've also had to add in a function which doesn't run testing on all platforms because it's complaining about an issue with port 8080 which I haven't got working yet, but while it'll need some subsequent cleanups this fundamentally seems to work and adds the successful production of Temurin `.deb` files on aarch64, ppc64le and s390x (armv7l fails because the machine I've been running on can't run with `-Xmx4g`.

I've removed the `JDK_SOURCE` switch because it wasn't doing much and when I duplicated the buildandtest function it created more duplication leaving it in. Any Jenkinsfile experts out there are more than welcome to improve the syntax as there's much to be improved, but we're under time pressure so while this isn't the most efficient method it does produce something that is usable. Limitations are as follows (all can be addressed in a future PR for expediency:

- the non-x64 `.deb` and everything else are run serially because you can't run a `matrix` inside a `parallel` block, which increases the runtime to around 40 minutes
- Ideally the non-x64 .debs would be run as a matrix job but needs `NODE_LABEL` to be dynamic for each item in the the axis (In fact we should do this for the Red Hat and SuSE ones too to make the process more generic and allow the parallelism to work across everything)
- armv7l doesn't work as the attempt to use a different `-Xmx` didn't take effect (I have built these manually though without the parameter)
- As mentioned, the tests don't run successfully for the new non-X64 .debs that are being produced

Resolves: https://github.com/adoptium/installer/issues/366