### PR TITLE
Fix provided packages list for Temurin RPM packages

### DIFF
--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -102,17 +102,28 @@ Requires: freetype%{?_isa}
 Provides: java
 Provides: java-11
 Provides: java-11-devel
+Provides: java-11-headless
 Provides: java-11-%{java_provides}
 Provides: java-11-%{java_provides}-devel
+Provides: java-11-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
 Provides: java-sdk-11
 Provides: java-sdk-11-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
 Provides: jre-11
+Provides: jre-11-headless
 Provides: jre-11-%{java_provides}
+Provides: jre-11-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -102,17 +102,28 @@ Requires: freetype%{?_isa}
 Provides: java
 Provides: java-17
 Provides: java-17-devel
+Provides: java-17-headless
 Provides: java-17-%{java_provides}
 Provides: java-17-%{java_provides}-devel
+Provides: java-17-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
 Provides: java-sdk-17
 Provides: java-sdk-17-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
 Provides: jre-17
+Provides: jre-17-headless
 Provides: jre-17-%{java_provides}
+Provides: jre-17-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -91,19 +91,30 @@ Requires: fontconfig%{?_isa}
 Requires: freetype%{?_isa}
 
 Provides: java
-Provides: java-8
-Provides: java-8-devel
-Provides: java-8-%{java_provides}
-Provides: java-8-%{java_provides}-devel
+Provides: java-1.8.0
+Provides: java-1.8.0-devel
+Provides: java-1.8.0-headless
+Provides: java-1.8.0-%{java_provides}
+Provides: java-1.8.0-%{java_provides}-devel
+Provides: java-1.8.0-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
-Provides: java-sdk-8
-Provides: java-sdk-8-%{java_provides}
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
+Provides: java-sdk-1.8.0
+Provides: java-sdk-1.8.0-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
-Provides: jre-8
-Provides: jre-8-%{java_provides}
+Provides: jre-1.8.0
+Provides: jre-1.8.0-headless
+Provides: jre-1.8.0-%{java_provides}
+Provides: jre-1.8.0-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -103,17 +103,28 @@ Requires: libfreetype6%{?_isa}
 Provides: java
 Provides: java-11
 Provides: java-11-devel
+Provides: java-11-headless
 Provides: java-11-%{java_provides}
 Provides: java-11-%{java_provides}-devel
+Provides: java-11-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
 Provides: java-sdk-11
 Provides: java-sdk-11-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
 Provides: jre-11
+Provides: jre-11-headless
 Provides: jre-11-%{java_provides}
+Provides: jre-11-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -102,17 +102,28 @@ Requires: libfreetype6%{?_isa}
 Provides: java
 Provides: java-17
 Provides: java-17-devel
+Provides: java-17-headless
 Provides: java-17-%{java_provides}
 Provides: java-17-%{java_provides}-devel
+Provides: java-17-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
 Provides: java-sdk-17
 Provides: java-sdk-17-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
 Provides: jre-17
+Provides: jre-17-headless
 Provides: jre-17-%{java_provides}
+Provides: jre-17-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -91,19 +91,30 @@ Requires: fontconfig%{?_isa}
 Requires: libfreetype6%{?_isa}
 
 Provides: java
-Provides: java-8
-Provides: java-8-devel
-Provides: java-8-%{java_provides}
-Provides: java-8-%{java_provides}-devel
+Provides: java-1.8.0
+Provides: java-1.8.0-devel
+Provides: java-1.8.0-headless
+Provides: java-1.8.0-%{java_provides}
+Provides: java-1.8.0-%{java_provides}-devel
+Provides: java-1.8.0-%{java_provides}-headless
 Provides: java-devel
+Provides: java-devel-%{java_provides}
+Provides: java-headless
 Provides: java-%{java_provides}
 Provides: java-%{java_provides}-devel
-Provides: java-sdk-8
-Provides: java-sdk-8-%{java_provides}
+Provides: java-%{java_provides}-headless
+Provides: java-sdk
+Provides: java-sdk-1.8.0
+Provides: java-sdk-1.8.0-%{java_provides}
+Provides: java-sdk-%{java_provides}
 Provides: jre
-Provides: jre-8
-Provides: jre-8-%{java_provides}
+Provides: jre-1.8.0
+Provides: jre-1.8.0-headless
+Provides: jre-1.8.0-%{java_provides}
+Provides: jre-1.8.0-%{java_provides}-headless
+Provides: jre-headless
 Provides: jre-%{java_provides}
+Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz


### PR DESCRIPTION
Examples of what packages default Java RPMs provide:
- https://centos.pkgs.org/8/centos-appstream-aarch64/java-1.8.0-openjdk-1.8.0.312.b07-2.el8_5.aarch64.rpm.html
- https://centos.pkgs.org/8/centos-appstream-aarch64/java-1.8.0-openjdk-devel-1.8.0.312.b07-2.el8_5.aarch64.rpm.html
- https://centos.pkgs.org/8/centos-appstream-aarch64/java-1.8.0-openjdk-headless-1.8.0.312.b07-2.el8_5.aarch64.rpm.html

Fixes #415