### PR TITLE
Update packaging for jdk-11.0.14+9

### DIFF
--- a/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,4 +1,8 @@
-temurin-11-jdk (11.0.13.0.0+8-1) UNRELEASED; urgency=medium
+temurin-11-jdk (11.0.14.0.0+9-1) UNRELEASED; urgency=medium
+
+  * Eclipse Temurin 11.0.14.0.0+9-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 1 Feb 2022 10:20:21 +0000
 
   * Eclipse Temurin 11.0.13.0.0+8-1 release.
 

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -4,6 +4,8 @@ temurin-11-jdk (11.0.14.0.0+9-1) UNRELEASED; urgency=medium
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 1 Feb 2022 10:20:21 +0000
 
+ temurin-11-jdk (11.0.13.0.0+8-1) UNRELEASED; urgency=medium 
+
   * Eclipse Temurin 11.0.13.0.0+8-1 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Fri, 13 Aug 2021 14:32:55 +0000

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jdk
 priority = 1111
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200 jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
-amd64_checksum = 3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.13_8.tar.gz
-arm64_checksum = a77013bff10a5e9c59159231dd5c4bd071fc4c24beed42bd49b82803ba9506ef
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.13_8.tar.gz
-armhf_checksum = 61ee45c4ef21a85a116a87e1bca2e2a420b3af432be8d801bd52c660ffebaa9f
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.13_8.tar.gz
-ppc64el_checksum = 82f14cda71cff99c878bf8400598a87235adb6c81b0337f7077c27e5cac1190c
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.13_8.tar.gz
-s390x_checksum = 9d280d86fdf6a7d9e5cbf54dc37f1d6d09dfe676ff5c684802fdfa3932eee63e
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.14_9.tar.gz
+amd64_checksum = 1189bee178d11402a690edf3fbba0c9f2ada1d3a36ff78929d81935842ef24a9
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.14_9.tar.gz
+arm64_checksum = 0ba188a2a739733163cd0049344429d2284867e04ca452879be24f3b54320c9a
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.14_9.tar.gz
+armhf_checksum = a0ba2fa6a982fe6c09c721ac9c72c8e5323991a529403daacac323549df4495d
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.14_9.tar.gz
+ppc64el_checksum = 91c63331faba8c842aef312d415b3e67aecf4f662a36c275f5cb278f7bce1410
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.14_9.tar.gz
+s390x_checksum = 4dd43e06830e62d65c698b393db10bab39ec6575de08db8d2f5b66cfe09c8c85
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -265,5 +265,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Sun Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
+* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
 - Eclipse Temurin 11.0.12+7 release.
+* Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.14.0.0.9-1.adopt0
+- Eclipse Temurin 11.0.14+9 release.

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.13+8
+%global upstream_version 11.0.14+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.13.0.0.8
+%global spec_version 11.0.14.0.0.9
 %global spec_release 1
 %global priority 1111
 

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -265,7 +265,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
-- Eclipse Temurin 11.0.12+7 release.
 * Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.14.0.0.9-1.adopt0
 - Eclipse Temurin 11.0.14+9 release.
+* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
+- Eclipse Temurin 11.0.12+7 release.

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -265,7 +265,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Fri Aug 13 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
-- Eclipse Temurin 17.0.0+35 release.
 * Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.2.0.0.8-1.adopt0
 - Eclipse Temurin 17.0.2+8 release. 
+* Fri Aug 13 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
+- Eclipse Temurin 17.0.0+35 release.

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -267,3 +267,5 @@ fi
 %changelog
 * Fri Aug 13 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
 - Eclipse Temurin 17.0.0+35 release.
+* Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.2.0.0.8-1.adopt0
+- Eclipse Temurin 17.0.2+8 release. 

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -253,7 +253,7 @@ fi
 %{prefix}
 
 %changelog
-* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
-- Eclipse Temurin 11.0.12+7 release.
 * Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.14.0.0.9-1.adopt0
 - Eclipse Temurin 11.0.14+9 release.
+* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
+- Eclipse Temurin 11.0.12+7 release.

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.13+8
+%global upstream_version 11.0.14+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.13.0.0.8
+%global spec_version 11.0.14.0.0.9
 %global spec_release 1
 %global priority 1111
 

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -253,5 +253,7 @@ fi
 %{prefix}
 
 %changelog
-* Sun Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
+* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.12.0.0.7-1.adopt0
 - Eclipse Temurin 11.0.12+7 release.
+* Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.14.0.0.9-1.adopt0
+- Eclipse Temurin 11.0.14+9 release.

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/16/temurin-16-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/16/temurin-16-jdk.spec
@@ -195,5 +195,5 @@ fi
 %{prefix}
 
 %changelog
-* Sun Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 16.0.2.0.0.7-1.adopt0
+* Tue Aug 10 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 16.0.2.0.0.7-1.adopt0
 - Eclipse Temurin 16.0.2+7 release.

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -252,7 +252,7 @@ fi
 %{prefix}
 
 %changelog
-* Thu Sep 23 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
-- Eclipse Temurin 17.0.0+35 release.
 * Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.2.0.0.8-1.adopt0
 - Eclipse Temurin 17.0.2+8 release.
+* Thu Sep 23 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
+- Eclipse Temurin 17.0.0+35 release.

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -254,3 +254,5 @@ fi
 %changelog
 * Thu Sep 23 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
 - Eclipse Temurin 17.0.0+35 release.
+* Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.2.0.0.8-1.adopt0
+- Eclipse Temurin 17.0.2+8 release.


### PR DESCRIPTION
All architectures are now available for JDK11.0.14+9.

Signed-off-by: Stewart X Addison <sxa@redhat.com>