### PR TITLE
Update packaging for jdk-17.0.2+8

### DIFF
--- a/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -3,3 +3,9 @@ temurin-17-jdk (17.0.2.0.0+8-1) UNRELEASED; urgency=medium
   * Eclipse Temurin 17.0.2.0.0+8-1 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 01 Feb 2022 14:16:30 +0000
+
+temurin-17-jdk (17.0.1.0.0+12-1) UNRELEASED; urgency=medium
+
+  * Eclipse Temurin 17.0.1.0.0+12-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 23 sep 2021 15:32:48 +0000

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,5 +1,5 @@
-temurin-17-jdk (17.0.1.0.0+12-1) UNRELEASED; urgency=medium
+temurin-17-jdk (17.0.2.0.0+8-1) UNRELEASED; urgency=medium
 
-  * Eclipse Temurin 17.0.1.0.0+12-1 release.
+  * Eclipse Temurin 17.0.2.0.0+8-1 release.
 
- -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 23 sep 2021 15:32:48 +0000
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 01 Feb 2022 14:16:30 +0000

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jdk
 priority = 1161
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz
-amd64_checksum = 6ea18c276dcbb8522feeebcfc3a4b5cb7c7e7368ba8590d3326c6c3efc5448b6
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz
-arm64_checksum = f23d482b2b4ada08166201d1a0e299e3e371fdca5cd7288dcbd81ae82f3a75e3
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz
-armhf_checksum = f5945a39929384235e7cb1c57df071b8c7e49274632e2a54e54b2bad05de21a5
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.1_12.tar.gz
-ppc64el_checksum = bd65d4e8ecc4236924ae34d2075b956799abca594021e1b40c36aa08a0d610b0
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.1_12.tar.gz
-s390x_checksum = dcc17e6ef28984656e997b6b8a6a31c89f45aff87a56b5d3819137c8f1050bef
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.2_8.tar.gz
+amd64_checksum = 288f34e3ba8a4838605636485d0365ce23e57d5f2f68997ac4c2e4c01967cd48
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.2_8.tar.gz
+arm64_checksum = 302caf29f73481b2b914ba2b89705036010c65eb9bc8d7712b27d6e9bedf6200
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_arm_linux_hotspot_17.0.2_8.tar.gz
+armhf_checksum = 544936145a4a9b1a316ed3708cd91b3960d5e8e87578bea73ef674ca3047158e
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.2_8.tar.gz
+ppc64el_checksum = 532d831d6a977e821b7331ecf9ed995e5bbfe76f18a1b00ffa8dbb3a4e2887de
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.2_8.tar.gz
+s390x_checksum = 383ac8ad392036bedab9a08eb55395b95593a6cc268c422a2bab53f0977a4c54
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.1+12
+%global upstream_version 17.0.2+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.1.0.0.12
+%global spec_version 17.0.2.0.0.8
 %global spec_release 1
 %global priority 1161
 

--- a/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linuxNew/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.1+12
+%global upstream_version 17.0.2+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.1.0.0.12
+%global spec_version 17.0.2.0.0.8
 %global spec_release 1
 %global priority 1161
 


### PR DESCRIPTION
Draft as arm32 and s390x are not yet published (Should be later today)

Also note that unlike #423 I have not included the old version in the Debian changelog for now as it is failing the checks. We'll need to do something consistent between 8 and 11 ...

Signed-off-by: Stewart X Addison <sxa@redhat.com>