### PR TITLE
mac: Trap case where nether hotspot or openj9 are in the filename

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -50,6 +50,10 @@ do tar -xf "$f";
     *openj9*)
       export JVM="openj9"
     ;;
+    *)
+      echo Cannot identify variant from filename "${f}" - only hotspot or openj9 are allowable
+      exit 1
+    ;;
   esac
 
   # Detect if JRE or JDK


### PR DESCRIPTION
Self-explanatory - traps the default condition which showed up before https://github.com/adoptium/ci-jenkins-pipelines/pull/241 went in. Error was an attempt to use an undefined variable.

```
pkgbuild/create-installer-mac.sh: line 79: JVM: unbound variable
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>