### PR TITLE
create_installer_windows failing with new "temurin" variant support

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -50,6 +50,10 @@ do tar -xf "$f";
     *openj9*)
       export JVM="openj9"
     ;;
+    *)
+      echo Cannot identify variant from filename "${f}" - only hotspot or openj9 are allowable
+      exit 1
+    ;;
   esac
 
   # Detect if JRE or JDK

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -70,6 +70,10 @@ IF NOT "%ARCH%" == "x64" (
 	)
 )
 
+REM Update to handle the change of build variant until implications
+REM of setting this to Temurin can be evaluated
+IF "%JVM%" == "temurin" SET JVM=hotspot
+
 IF NOT "%JVM%" == "hotspot" (
 	IF NOT "%JVM%" == "openj9" (
 	    IF NOT "%JVM%" == "dragonwell" (


### PR DESCRIPTION
Fix for the following error in [create_installer_windows](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_windows):
```
JVM "temurin" not supported : valid values : hotspot, openj9, dragonwell, hotspot openj9, openj9 hotspot
```
This just maps `JVM=temurin` to `JVM=hotspot` to ensure all the values are the same as before. Happy to entertain a discussion on whether this should be changed in the future but for now this should allow the installer to be generated the same as it was before the changes.
Signed-off-by: Stewart X Addison <sxa@redhat.com>