### PR TITLE
Using single-quotes instead of double-quotes when reference credentials

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -144,7 +144,7 @@ def buildAndTest(DISTRO, arch) {
     if (DISTRO != "Debian") {
         // Install Adoptium GPG key for RPM signing
         withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
-            sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY}")
+            sh('./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY}')
         }
     } else if (arch == 'x64') {
         sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")


### PR DESCRIPTION
Using single-quotes instead of double-quotes when referencing these sensitive environment variables prevents this type of leaking. 

The current job get information 'The following steps that have been detected may have insecure interpolation of sensitive variables'

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>