### PR TITLE
pkgbuild: ensure that ARCH is valid

### DIFF
--- a/pkgbuild/packagesbuild.sh
+++ b/pkgbuild/packagesbuild.sh
@@ -111,6 +111,16 @@ while test $# -gt 0; do
   esac
 done
 
+# Ensures that ARCHITECTURE is valid to avoid incorrectly compiled PKGs
+case $ARCHITECTURE in
+  x86_64) ;;
+  arm64) ;;
+  *)
+    echo "Unknown architecture: $ARCHITECTURE"
+    exit 1
+    ;;
+esac
+
 case $JVM in
   openj9)
     if [ -z "$IDENTIFIER" ]; then


### PR DESCRIPTION
Internally we realised that it was possible to create a PKG with an invalid architecture specified so this PR sanitises the value before building