### PR TITLE
Stop stripping binaries in debian packages

### DIFF
--- a/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -25,6 +25,7 @@ pkg_alias = $(pkg_name)-$(DEB_HOST_ARCH)
 override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
+override_dh_strip:
 override_dh_auto_install:
 	# Download and verify checksum of JDK
 	wget --progress=dot:mega -O jdk.tar.gz $($(DEB_HOST_ARCH)_tarball_url)

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/16/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/16/debian/rules
@@ -19,6 +19,7 @@ pkg_alias = $(pkg_name)-$(DEB_HOST_ARCH)
 override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
+override_dh_strip:
 override_dh_auto_install:
 	# Download and verify checksum of JDK
 	wget --progress=dot:mega -O jdk.tar.gz $($(DEB_HOST_ARCH)_tarball_url)

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -25,6 +25,7 @@ pkg_alias = $(pkg_name)-$(DEB_HOST_ARCH)
 override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
+override_dh_strip:
 override_dh_auto_install:
 	# Download and verify checksum of JDK
 	wget --progress=dot:mega -O jdk.tar.gz $($(DEB_HOST_ARCH)_tarball_url)

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/18/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/18/debian/rules
@@ -25,6 +25,7 @@ pkg_alias = $(pkg_name)-$(DEB_HOST_ARCH)
 override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
+override_dh_strip:
 override_dh_auto_install:
 	# Download and verify checksum of JDK
 	wget --progress=dot:mega -O jdk.tar.gz $($(DEB_HOST_ARCH)_tarball_url)

--- a/linuxNew/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linuxNew/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -24,6 +24,7 @@ pkg_alias = $(pkg_name)-$(DEB_HOST_ARCH)
 override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
+override_dh_strip:
 override_dh_auto_install:
 	# Download and verify checksum of JDK
 	wget --progress=dot:mega -O jdk.tar.gz $($(DEB_HOST_ARCH)_tarball_url)


### PR DESCRIPTION
Fixes https://github.com/adoptium/installer/issues/443

Tested at https://ci.adoptopenjdk.net/job/adoptium-packages-linux-pipeline/115/:
Previous version (Footprint on disk = 298448Kb:
```
root@odroid-1:/home/sxa# file /usr/lib/jvm/temurin-17-jdk-armhf/lib/libjava.so
/usr/lib/jvm/temurin-17-jdk-armhf/lib/libjava.so: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, stripped
root@odroid-1:/home/sxa# file /usr/lib/jvm/temurin-17-jdk-armhf/bin/java
/usr/lib/jvm/temurin-17-jdk-armhf/bin/java: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, stripped
```
New version (Footprint on disk = 305360Kb)
```
root@odroid-1:/home/sxa# file /usr/lib/jvm/temurin-17-jdk-armhf/lib/libjava.so
/usr/lib/jvm/temurin-17-jdk-armhf/lib/libjava.so: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, not stripped
root@odroid-1:/home/sxa# file /usr/lib/jvm/temurin-17-jdk-armhf/bin/java
/usr/lib/jvm/temurin-17-jdk-armhf/bin/java: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, not stripped
root@odroid-1:/home/sxa# 
```