### PR TITLE
linuxNew: add support for Ubuntu Jammy (22.04)

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -172,7 +172,7 @@ def uploadDebArtifacts(buildArch) {
         "s390x" : "s390x"
     ]
     def distro_list = ""
-    def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute"]
+    def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
     deb_versions.each { distro ->
         // Creates list like deb.distribution=stretch;deb.distribution=buster;
         distro_list += "deb.distribution=${distro};"

--- a/linuxNew/ca-certificates/debian/build.gradle
+++ b/linuxNew/ca-certificates/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute"]
+def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linuxNew/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
+++ b/linuxNew/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
@@ -37,6 +37,6 @@ class ChangesVerificationTest {
 		assertThat(changesFile).exists();
 
 		List<String> lines = Files.readAllLines(changesFile, StandardCharsets.UTF_8);
-		assertThat(lines).contains("Distribution: stretch buster bullseye bionic focal groovy hirsute");
+		assertThat(lines).contains("Distribution: stretch buster bullseye bionic focal groovy hirsute jammy");
 	}
 }

--- a/linuxNew/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
+++ b/linuxNew/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
@@ -38,7 +38,8 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "bullseye"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "hirsute")
+			Arguments.of("ubuntu", "hirsute"),
+			Arguments.of("ubuntu", "jammy")
 		);
 	}
 }

--- a/linuxNew/jdk/debian/build.gradle
+++ b/linuxNew/jdk/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute"]
+def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linuxNew/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linuxNew/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -38,7 +38,8 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "bullseye"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "hirsute")
+			Arguments.of("ubuntu", "hirsute"),
+			Arguments.of("ubuntu", "jammy")
 		);
 	}
 }


### PR DESCRIPTION
Ubuntu Jammy is the latest LTS release of Ubuntu so needs to be added to the installer matrix