### PR TITLE
feat: add capability to run installer per jdk version or distro selection 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,7 @@ jobs:
           architecture: x64
           distribution: 'temurin'
 
-      - name: Build
+      - name: Build # only simulate in Jenkins when select ARCH="all"
         run: |
           export _JAVA_OPTIONS="-Xmx4G"
           export DOCKER_BUILDKIT=1

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -1,126 +1,134 @@
-NODE_LABEL = "dockerBuild&&linux&&x64" // Dynamic docker machines from Azure
+/*
+--------------------------------------------
+buildArch   RPM         DEB         Comments
+--------------------------------------------
+x86_64      x86_64      amd64
+armv7l      armv7hl     armhf       arm32
+aarch64     aarch64     arm64       arm64
+ppc64le     ppc64le     ppc64le
+source      src         -           only for SRPM and no need specify as option or target
+s390x       s390x       s390x       only for jdk8+
+*/
+
+env.NODE_LABEL_RPM = "dockerBuild&&linux&&x64" // RedHat + Suse + Debian x64
+env.NODE_LABEL_DEB = "docker&&linux&&${ARCH}"  // Debian non-x64 
+env.PRODUCT = "temurin"
 
 pipeline {
     agent {
-        label NODE_LABEL
+        label NODE_LABEL_RPM
+    }
+    options {
+        timeout(time: 2, unit: 'HOURS') 
     }
     parameters {
-        string(name: 'PRODUCT', defaultValue: 'temurin')
-        string(name: 'JDK_SOURCE', defaultValue: 'Adoptium')
-        choice(name: 'VERSION_FILTER', choices: ['8', '11', '17', '18', 'all'], description: 'Build for specific VERSION')
-        choice(name: 'DISTRO_FILTER', choices: ['all', 'Debian', 'RedHat', 'Suse'], description: 'Build for specific Distro')
-        booleanParam(name: 'UPLOAD', defaultValue: false, description: 'Tick this box to upload the deb/rpm files to Artifactory')
+        choice(name: 'VERSION', choices: ['8', '11', '17', '18'], description: 'Build for specific JDK VERSION')
+        choice(name: 'ARCH', choices: ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x', 'all'], description: "Build for specific platform\n s300x not for VERSION 8\n")
+        choice(name: 'DISTRO', choices: ['all', 'Debian', 'RedHat', 'Suse'], description: 'Build for specific Distro\n Select RPM builds for RedHat and Suse')
+        booleanParam(name: 'uploadPackage', defaultValue: false, description: 'Tick this box to upload the deb/rpm files exlude src.rpm to Artifactory')
+        booleanParam(name: 'uploadSRCRPM', defaultValue: false, description: 'Tick this box to upload the src.rpm files to Artifactory')
+        string(name: 'gitrepo', defaultValue: 'https://github.com/adoptium/installer', description: 'Do not modify unless want to build from a specific gitrepo')
+        string(name: 'gitbranch', defaultValue: 'master', description: 'Do not change unless want to build on a specific branch from above gitrepo')
+        booleanParam(name: 'enableDebug', defaultValue: false, description: 'Tick to enable --stacktrace for gradle build')
+    }
+    tools {
+        // this is set in the jenkins global tool
+        jdk "jdk-11.0.13+8"
     }
     stages {
-        stage('Linux-x64 Installers') {
-            matrix {
-                agent {
-                    label NODE_LABEL
+        stage ("Prepare Build"){
+            steps{
+                script{
+                    currentBuild.displayName =  "jdk${VERSION} - ${ARCH} - ${DISTRO}"
+                    currentBuild.description = env.BUILD_USER_ID
+                    sh("docker --version")
                 }
-                tools {
-                    jdk "jdk-11.0.13+8"
-                }
-                when {
-                    allOf {
-                        anyOf {
-                            expression { params.VERSION_FILTER == 'all' }
-                            expression { params.VERSION_FILTER == env.VERSION }
-                        }
-                        anyOf {
-                            expression { params.DISTRO_FILTER == 'all' }
-                            expression { params.DISTRO_FILTER == env.DISTRO }
-                        }
-                    }
-                }
-                axes {
-                    axis {
-                        name 'DISTRO'
-                        values 'Debian', 'RedHat', 'Suse'
-                    }
-                    axis {
-                        name 'VERSION'
-                        values '8', '11', '17', '18'
-                    }
-                }
-                stages {
-                    stage('Build Installer') {
-                        steps {
-                                echo "Installer Job for Temurin ${VERSION} - ${DISTRO}"
-                                setup()
-                                dir('linux') {
-                                    buildAndTest(DISTRO, 'x64')
-                                }
-                                script {
-                                    if (UPLOAD.toBoolean()) {
-                                        uploadArtifacts(DISTRO, 'amd64')
-                                    }
-                                }
-                            }
-                    }
+                checkout(
+                    [
+                        $class: 'GitSCM',
+                        branches: [[name: "$gitbranch"]],
+                        extensions: [[$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true]],
+                        userRemoteConfigs: [[url: "$gitrepo"]]
+                    ]
+                )
+                dir("linux") {
+                    stash name: "installercode", includes: "**"
                 }
             }
         }
-        stage('Run non-x64 Deb packaging in parallel') {
-            when {
-                anyOf {
-                    expression { params.DISTRO_FILTER == 'all' }
-                    expression { params.DISTRO_FILTER == 'Debian' }
-                }
-            }
-            matrix {
-                tools {
-                    jdk "jdk-11.0.13+8"
-                }
-                when {
-                    anyOf {
-                        expression { params.VERSION_FILTER == 'all' }
-                        expression { params.VERSION_FILTER == env.VERSION }
-                    }
-                }
-                axes {
-                    axis {
-                        name 'ARCH'
-                        values 'aarch64', 'ppc64le', 's390x', 'armv7l'
-                    }
-                    axis {
-                        name 'VERSION'
-                        values '8', '11', '17', '18'
-                    }
-                }
-                excludes {
-                    exclude {
-                        axis {
-                            name 'ARCH'
-                            values 's390x'
+        stage ("BUILD")
+        {
+            parallel{
+                stage('Build Installer for Debian') {
+                    when  {
+                        beforeAgent true
+                        anyOf {
+                            expression{ params.DISTRO == 'all' }  // trigger debian build
+                            expression{ params.DISTRO == 'Debian' }
                         }
-                        axis {
-                            name 'VERSION'
-                            values '8'
+                    }
+                    agent {
+                        label "${ARCH}" == "x86_64" ? "${env.NODE_LABEL_RPM}": "${env.NODE_LABEL_DEB}"
+                    }
+                    steps{
+                        dir('linuxDebian') {
+                            script {
+                                DISTRO = "Debian"
+                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+                                setup("${DISTRO}", "${ARCH}")
+                                unstash 'installercode'
+                                buildAndTest("${DISTRO}", "${ARCH}")
+                                if (params.uploadPackage.toBoolean()) {
+                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
+                                    uploadArtifacts("${DISTRO}", "${ARCH}")
+                                }
+                            }
                         }
                     }
                 }
-                agent {
-                    label "docker&&linux&&${ARCH}"
+                stage('Build Installer for Redhat') {
+                    when  {
+                        beforeAgent true
+                        anyOf {
+                            expression{ params.DISTRO == 'all' }  // trigger debian build
+                            expression{ params.DISTRO == 'RedHat' }
+                        }
+                    }
+                    steps{
+                        dir('linuxRedHat') {
+                            script {
+                                DISTRO = "RedHat"
+                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+                                setup("${DISTRO}", "${ARCH}")
+                                unstash 'installercode'
+                                buildAndTest("${DISTRO}", "${ARCH}")
+                                if (params.uploadPackage.toBoolean()) {
+                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
+                                    uploadArtifacts("${DISTRO}", "${ARCH}")
+                                }
+                            }
+                        }
+                    }
                 }
-                stages {
-                    stage('Build Installer') {
-                        steps {
-                            echo "Debian Installer Job for Temurin ${VERSION} - on ${ARCH}"
-                            setup()
+                stage('Build Installer for Suse') {
+                    when  {
+                        beforeAgent true // do condition when before allocate to agent
+                        anyOf {
+                            expression{ params.DISTRO == 'all' }  // trigger debian build
+                            expression{ params.DISTRO == 'Suse' }
+                        }
+                    }
+                    steps{
+                        dir('linuxSuse') {
                             script {
-                                if (ARCH == "s390x") {
-                                    env.DOCKER_BUILDKIT=0
-                                }
-                                if (ARCH == "armv7l") {
-                                    env._JAVA_OPTIONS=""
-                                }
-                            }
-                            dir('linux') {
-                                buildAndTest('Debian', ARCH)
-                            }
-                            script {
-                                if (UPLOAD.toBoolean()) {
-                                    uploadArtifacts('Debian', ARCH)
+                                DISTRO = "Suse"
+                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+                                setup("${DISTRO}", "${ARCH}")
+                                unstash 'installercode'
+                                buildAndTest("${DISTRO}", "${ARCH}")
+                                if (params.uploadPackage.toBoolean()) {
+                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
+                                    uploadArtifacts("${DISTRO}", "${ARCH}")
                                 }
                             }
                         }
@@ -131,69 +139,92 @@ pipeline {
     }
 }
 
-def setup() {
+/*
+* Common Functions
+*/
+def setup(DISTRO, buildArch) {
     cleanWs()
     // Docker --mount option requires BuildKit
-    env.DOCKER_BUILDKIT=1
-    env._JAVA_OPTIONS="-Xmx4g"
-    checkout scm
+    env.DOCKER_BUILDKIT = buildArch == "s390x" ? '0' : '1'
+    env.COMPOSE_DOCKER_CLI_BUILD=1
+    env._JAVA_OPTIONS =  (buildArch == "armv7l" && DISTRO == "Debian")? "" : "-Xmx4g"
 }
 
-def buildAndTest(DISTRO, arch) {
-    if (DISTRO != "Debian") {
-        // Install Adoptium GPG key for RPM signing
-        withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
-            sh('./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY}')
+def buildAndTest(DISTRO, buildArch) {
+    try {
+        if (DISTRO != "Debian") { // for RPM based: RedHat / Suse
+            // Install Adoptium GPG key for RPM signing
+            withCredentials([file(credentialsId: 'adoptium-artifactory-gpg-key', variable: 'GPG_KEY')]) {
+                def buildCLI = "./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PGPG_KEY=${GPG_KEY} -PARCH=${buildArch}"
+                buildCLI = params.enableDebug.toBoolean() ? buildCLI + " --stacktrace" : buildCLI
+                sh("$buildCLI")
+            }
+        } else {
+            def gBuildTask = (buildArch == 'x86_64') ? "packageJdk${DISTRO} checkJdk${DISTRO}" : "packageJdk${DISTRO}"
+            def debArchList = [
+                "x86_64" : "amd64",
+                "armv7l": "armhf",
+                "aarch64": "arm64",
+                "ppc64le": "ppc64el",
+                "s390x"  : "s390x"
+            ]
+            def buildCLI = "./gradlew ${gBuildTask} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${debArchList[buildArch]}"
+            buildCLI = params.enableDebug.toBoolean() ? buildCLI + " --stacktrace" : buildCLI
+            sh("$buildCLI")
         }
-    } else if (arch == 'x64') {
-        sh("./gradlew packageJdk${DISTRO} checkJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
-    } else {
-        // Current tests are not supported on non-x64 platform
-        sh("./gradlew packageJdk${DISTRO} --parallel -PPRODUCT=${PRODUCT} -PPRODUCT_VERSION=${VERSION}")
+    } catch (Exception ex) {
+        echo 'Exception in buildAndTest: ' + ex.toString() 
+        currentBuild.result = 'FAILURE'  // set the whole pipeline 'red' if build or test fail. Do not use "error" that will not call "finally"
+    } finally {
+        archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*', onlyIfSuccessful:false, allowEmptyArchive: true
     }
-    archiveArtifacts artifacts: '**/build/ospackage/*,**/build/reports/**,**/packageTest/dependencies/deb/*'
 }
 
-def uploadArtifacts(distro, arch) {
-    if (distro == "Debian") {
-        uploadDebArtifacts(arch)
-    } else {
-        uploadRPMArtifacts(distro)
+def uploadArtifacts(DISTRO, buildArch) {
+    if (DISTRO == "Debian") {
+        uploadDebArtifacts(buildArch)
+    } else {  // DISTRO == RPM(RedHat||Suse)
+        uploadRPMArtifacts(DISTRO)
     }
 }
 
 def uploadDebArtifacts(buildArch) {
-    def archs = [
-        "amd64" : "amd64",
-        "ppc64le": "ppc64el",
-        "aarch64": "arm64",
+    // full list of all platforms, up to user to opt out s390x+jdk8
+    def debArchList = [
+        "x86_64" : "amd64",
         "armv7l": "armhf",
-        "s390x" : "s390x"
+        "aarch64": "arm64",
+        "ppc64le": "ppc64el",
+        "s390x"  : "s390x"
     ]
-    def distro_list = ""
+    /*
+        Debian/Ubuntu   10.0       11.0        16.04     20.04    22.04
+        add more into list when avaiable for release
+        also update linux/jdk/debian/main/packing/build.sh
+    */
     def deb_versions = ["buster", "bullseye", "bionic", "focal", "jammy"]
-    deb_versions.each { distro ->
-        // Creates list like deb.distribution=bullseye;deb.distribution=bullseye;
-        distro_list += "deb.distribution=${distro};"
+    def distro_list = ""
+    deb_versions.each { deb_version ->
+        // Creates list like deb.distribution=stretch;deb.distribution=buster;
+        distro_list += "deb.distribution=${deb_version};"
     }
-    def arch = archs.get(buildArch)
-    rtUpload (
+
+    rtUpload ( //artifactory plugin
         serverId: 'adoptium.jfrog.io',
         failNoOp: true,
         spec: """{
             "files": [
                 {
-                "pattern": "**/build/ospackage/temurin-*${arch}.deb",
+                "pattern": "**/build/ospackage/temurin-*${debArchList[buildArch]}.deb",
                 "target": "deb/pool/main/t/temurin-${VERSION}/",
-                "props": "${distro_list}deb.component=main;deb.architecture=${arch}"
+                "props": "${distro_list}deb.component=main;deb.architecture=${debArchList[buildArch]}"
                 }
             ]
         }""",
     )
 }
 
-def uploadRPMArtifacts(distro) {
-    def tempDistro = distro.toLowerCase()
+def uploadRPMArtifacts(DISTRO) {
     def distro_Package = [
         'redhat' : [
             'rpm/centos/7',
@@ -203,9 +234,10 @@ def uploadRPMArtifacts(distro) {
             'rpm/rhel/9',
             'rpm/fedora/35',
             'rpm/fedora/36',
+            'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',
             'rpm/amazonlinux/2',
-            'rpm/oraclelinux/7'
+
         ],
         'suse'   : [
             'rpm/opensuse/15.3',
@@ -214,22 +246,22 @@ def uploadRPMArtifacts(distro) {
             'rpm/sles/15'
         ]
     ]
-    def archs = [
+    def packageDirs = distro_Package[DISTRO.toLowerCase()]
+    // full list of all platforms, up to user to opt out s390x+jdk8 from input
+    def rpmArchList = [
         "x86_64" : "x86_64",
-        "ppc64le": "ppc64le",
+        "armv7l": "armv7hl",
         "aarch64": "aarch64",
-        "armv7hl": "armv7hl",
-        "source" : "src"
+        "ppc64le": "ppc64le",
+        "source" : "src",  // here we need src in the list to be able to upload
+        "s390x"  : "s390x"
     ]
-    def packageDirs = distro_Package.get(tempDistro)
-    
-    if ( !VERSION.equals("8") ) {
-        archs.put("s390x", "s390x")
-    }
+    // Enable upload src.rpm
+    if ( params.uploadSRCRPM.toBoolean() || params.DISTRO == 'all'){   rpmArchList.put("Source","src") }
 
     packageDirs.each {
         packageDir ->
-            archs.each {
+            rpmArchList.each {
                 entry -> rtUpload (
                     serverId: 'adoptium.jfrog.io',
                     failNoOp: true,

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         choice(name: 'VERSION', choices: ['8', '11', '17', '19'], description: 'Build for specific JDK VERSION')
         choice(name: 'ARCH', choices: ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x', 'all'], description: "Build for specific platform\n s300x not for VERSION 8\n")
         choice(name: 'DISTRO', choices: ['all', 'Debian', 'RedHat', 'Suse'], description: 'Build for specific Distro\n Select RPM builds for RedHat and Suse')
-        booleanParam(name: 'uploadPackage', defaultValue: false, description: 'Tick this box to upload the deb/rpm files exlude src.rpm to Artifactory')
-        booleanParam(name: 'uploadSRCRPM', defaultValue: false, description: 'Tick this box to upload the src.rpm files to Artifactory')
+        booleanParam(name: 'uploadPackage', defaultValue: false, description: 'Tick this box to upload the deb/rpm files (exclude src.rpm) to Artifactory for official release')
+        booleanParam(name: 'uploadSRCRPM', defaultValue: false, description: 'Tick this box to upload (src.rpm files) to Artifactory')
         string(name: 'gitrepo', defaultValue: 'https://github.com/adoptium/installer', description: 'Do not modify unless want to build from a specific gitrepo')
         string(name: 'gitbranch', defaultValue: 'master', description: 'Do not change unless want to build on a specific branch from above gitrepo')
         booleanParam(name: 'enableDebug', defaultValue: false, description: 'Tick to enable --stacktrace for gradle build')
@@ -242,11 +242,12 @@ def uploadRPMArtifacts(DISTRO) {
         "armv7l": "armv7hl",
         "aarch64": "aarch64",
         "ppc64le": "ppc64le",
-        "source" : "src",  // here we need src in the list to be able to upload
         "s390x"  : "s390x"
     ]
     // Enable upload src.rpm
-    if ( params.uploadSRCRPM.toBoolean() || params.DISTRO == 'all'){   rpmArchList.put("Source","src") }
+    if ( params.uploadSRCRPM.toBoolean() || params.DISTRO == 'all' ) {
+        rpmArchList.put("source","src")
+    }
 
     packageDirs.each {
         packageDir ->

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -122,7 +122,8 @@ pipeline {
 def setup(DISTRO, buildArch) {
     cleanWs()
     // Docker --mount option requires BuildKit
-    env.DOCKER_BUILDKIT = buildArch == "s390x" ? '0' : '1'
+//    env.DOCKER_BUILDKIT = buildArch == "s390x" ? '0' : '1'
+    env.DOCKER_BUILDKIT = 1 
     env.COMPOSE_DOCKER_CLI_BUILD=1
     env._JAVA_OPTIONS =  (buildArch == "armv7l" && DISTRO == "Debian")? "" : "-Xmx4g"
 }

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -73,15 +73,7 @@ pipeline {
                     steps{
                         dir('linuxDebian') {
                             script {
-                                DISTRO = "Debian"
-                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-                                setup("${DISTRO}", "${ARCH}")
-                                unstash 'installercode'
-                                buildAndTest("${DISTRO}", "${ARCH}")
-                                if (params.uploadPackage.toBoolean()) {
-                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
-                                    uploadArtifacts("${DISTRO}", "${ARCH}")
-                                }
+                                jenkinsStep("Debian")
                             }
                         }
                     }
@@ -98,14 +90,7 @@ pipeline {
                         dir('linuxRedHat') {
                             script {
                                 DISTRO = "RedHat"
-                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-                                setup("${DISTRO}", "${ARCH}")
-                                unstash 'installercode'
-                                buildAndTest("${DISTRO}", "${ARCH}")
-                                if (params.uploadPackage.toBoolean()) {
-                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
-                                    uploadArtifacts("${DISTRO}", "${ARCH}")
-                                }
+                                jenkinsStep("RedHat")
                             }
                         }
                     }
@@ -121,15 +106,7 @@ pipeline {
                     steps{
                         dir('linuxSuse') {
                             script {
-                                DISTRO = "Suse"
-                                echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-                                setup("${DISTRO}", "${ARCH}")
-                                unstash 'installercode'
-                                buildAndTest("${DISTRO}", "${ARCH}")
-                                if (params.uploadPackage.toBoolean()) {
-                                    echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
-                                    uploadArtifacts("${DISTRO}", "${ARCH}")
-                                }
+                                jenkinsStep("Suse")
                             }
                         }
                     }
@@ -148,6 +125,17 @@ def setup(DISTRO, buildArch) {
     env.DOCKER_BUILDKIT = buildArch == "s390x" ? '0' : '1'
     env.COMPOSE_DOCKER_CLI_BUILD=1
     env._JAVA_OPTIONS =  (buildArch == "armv7l" && DISTRO == "Debian")? "" : "-Xmx4g"
+}
+
+def jenkinsStep(DISTRO){
+    echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+    setup("${DISTRO}", "${ARCH}")
+    unstash 'installercode'
+    buildAndTest("${DISTRO}", "${ARCH}")
+    if (params.uploadPackage.toBoolean()) {
+        echo "Upload artifacts for ${VERSION} - ${ARCH} - ${DISTRO}"
+        uploadArtifacts("${DISTRO}", "${ARCH}")
+    }
 }
 
 def buildAndTest(DISTRO, buildArch) {

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -63,8 +63,8 @@ pipeline {
                     when  {
                         beforeAgent true
                         anyOf {
-                            expression{ params.DISTRO == 'all' }  // trigger debian build
-                            expression{ params.DISTRO == 'Debian' }
+                            expression{ params.DISTRO == 'all' }  
+                            expression{ params.DISTRO == 'Debian' } // only trigger debian build
                         }
                     }
                     agent {
@@ -90,8 +90,8 @@ pipeline {
                     when  {
                         beforeAgent true
                         anyOf {
-                            expression{ params.DISTRO == 'all' }  // trigger debian build
-                            expression{ params.DISTRO == 'RedHat' }
+                            expression{ params.DISTRO == 'all' }
+                            expression{ params.DISTRO == 'RedHat' }  // only trigger redhat build
                         }
                     }
                     steps{
@@ -114,8 +114,8 @@ pipeline {
                     when  {
                         beforeAgent true // do condition when before allocate to agent
                         anyOf {
-                            expression{ params.DISTRO == 'all' }  // trigger debian build
-                            expression{ params.DISTRO == 'Suse' }
+                            expression{ params.DISTRO == 'all' }
+                            expression{ params.DISTRO == 'Suse' } // only trigger suse build
                         }
                     }
                     steps{

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         timeout(time: 2, unit: 'HOURS') 
     }
     parameters {
-        choice(name: 'VERSION', choices: ['8', '11', '17', '18'], description: 'Build for specific JDK VERSION')
+        choice(name: 'VERSION', choices: ['8', '11', '17', '19'], description: 'Build for specific JDK VERSION')
         choice(name: 'ARCH', choices: ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x', 'all'], description: "Build for specific platform\n s300x not for VERSION 8\n")
         choice(name: 'DISTRO', choices: ['all', 'Debian', 'RedHat', 'Suse'], description: 'Build for specific Distro\n Select RPM builds for RedHat and Suse')
         booleanParam(name: 'uploadPackage', defaultValue: false, description: 'Tick this box to upload the deb/rpm files exlude src.rpm to Artifactory')

--- a/linux/README.md
+++ b/linux/README.md
@@ -178,7 +178,7 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 ### RPM (RedHat and Suse)
 Supported JDK version 8,11,17,18
 
-Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk8+)
+Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk > 8)
 SRPM also available.
 
 | Distr            | Test enabled platforms | Note |

--- a/linux/README.md
+++ b/linux/README.md
@@ -160,9 +160,9 @@ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
 ## Supported packages
 
 ### DEB
-Supported JDK version 8,11,17,18 
+Supported JDK version 8,11,17,18
 
-Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk11+)  
+Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk8+)
 
 | Distr        | Test enabled platforms | Note |
 |--------------|:----------------------:|:----:|
@@ -178,7 +178,7 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 ### RPM (RedHat and Suse)
 Supported JDK version 8,11,17,18
 
-Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk11+)
+Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk8+)
 SRPM also available.
 
 | Distr            | Test enabled platforms | Note |

--- a/linux/README.md
+++ b/linux/README.md
@@ -162,7 +162,7 @@ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
 ### DEB
 Supported JDK version 8,11,17,18
 
-Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk8+)
+Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk > 8)
 
 | Distr        | Test enabled platforms | Note |
 |--------------|:----------------------:|:----:|

--- a/linux/README.md
+++ b/linux/README.md
@@ -30,7 +30,7 @@ You'll want to make sure you've set the exact versions of the binaries you want 
 
 In all of the examples below you'll need to replace the following variables:
 
-* Replace `<version>` with `8|11|17|18`
+* Replace `<version>` with `8|11|17|19`
 * Replace `<vendor>` with `temurin|dragonwell`
 * Replace `<platform>` with `Debian|RedHat|Suse`
 
@@ -56,7 +56,7 @@ _src/packageTest/java/packaging_ on them.
 
 ### Build a Debian specific package for a version
 
-- replace `<version>` with `8|11|17|18`
+- replace `<version>` with `8|11|17|19`
 - replace `<vendor>` with `temurin|dragonwell`
 
 ```shell
@@ -78,7 +78,7 @@ export _JAVA_OPTIONS="-Xmx4g"
 
 ### Build a SUSE specific package for a version
 
-- replace `<version>` with `8|11|17|18`
+- replace `<version>` with `8|11|17|19`
 - replace `<vendor>` with `temurin|dragonwell`
 
 ```shell
@@ -160,7 +160,7 @@ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
 ## Supported packages
 
 ### DEB
-Supported JDK version 8,11,17,18
+Supported JDK version 8,11,17,18,19
 
 Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk > 8)
 
@@ -176,7 +176,7 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 | ubuntu/18.04 |         x86_64         |      |
 
 ### RPM (RedHat and Suse)
-Supported JDK version 8,11,17,18
+Supported JDK version 8,11,17,18,19
 
 Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk > 8)
 SRPM also available.

--- a/linux/build.gradle
+++ b/linux/build.gradle
@@ -43,3 +43,7 @@ def getProductVersion() {
 def getGPGKey() {
 	return hasProperty("GPG_KEY") ? GPG_KEY.toString() : null
 }
+
+def getArch() {
+	return hasProperty("ARCH") ? ARCH.toString() : "all"
+}

--- a/linux/jdk/debian/build.gradle
+++ b/linux/jdk/debian/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 ext {
-	junitVersion = "5.7.0"
-	testcontainersVersion = "1.15.1"
-	assertjCoreVersion = "3.18.1"
+	junitVersion = "5.9.0"
+	testcontainersVersion = "1.17.3"
+	assertjCoreVersion = "3.23.1"
 }
 
 repositories {
@@ -24,8 +24,6 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["buster", "bullseye", "bionic", "focal", "jammy"]
-
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8
 	targetCompatibility = JavaVersion.VERSION_1_8
@@ -68,6 +66,7 @@ task packageJdkDebian {
 
 	def product = getProduct()
 	def productVersion = getProductVersion()
+	def arch = getArch()
 
 	doLast {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
@@ -88,10 +87,11 @@ task packageJdkDebian {
 
 		project.exec {
 			workingDir getRootDir()
-			commandLine "docker", "run", "--rm",
+			commandLine "docker", "run",
+				"--rm",
+				"-e", "buildArch=${arch}",
 				"--mount", "type=bind,source=${buildDir},target=/home/builder/build",
 				"--mount", "type=bind,source=${outputDir.absolutePath},target=/home/builder/out",
-				"-e", "VERSIONS=${String.join(" ", deb_versions)}",
 				"adoptium-packages-linux-jdk-debian:latest"
 		}
 	}

--- a/linux/jdk/debian/src/main/packaging/build.sh
+++ b/linux/jdk/debian/src/main/packaging/build.sh
@@ -13,7 +13,7 @@ dpkgExtraARG="-us -uc" # ignore building with a gpg key
 
 echo "DEBUG: building Debian arch ${buildArch}"
 if [[ "${buildArch}" == "all" ]]; then
-	dpkgExtraARG="${dpkgExtraARG} -b" # equal to --build=any,all|--build=binary
+    dpkgExtraARG="${dpkgExtraARG} -b" # equal to --build=any,all|--build=binary
 else
     dpkgExtraARG="${dpkgExtraARG} --build=any"
 fi

--- a/linux/jdk/debian/src/main/packaging/build.sh
+++ b/linux/jdk/debian/src/main/packaging/build.sh
@@ -6,11 +6,22 @@ set -euxo pipefail
 mkdir /home/builder/workspace
 cp -R /home/builder/build/generated/packaging /home/builder/workspace
 
-# Build package and set distributions it supports.
-# $VERSIONS are container env. variables
+
+# $ and $ARCH are env variables passing in from "docker run"
+debVersionList="buster bullseye bionic focal jammy"
+dpkgExtraARG="-us -uc" # ignore building with a gpg key
+
+echo "DEBUG: building Debian arch ${buildArch}"
+if [[ "${buildArch}" == "all" ]]; then
+	dpkgExtraARG="${dpkgExtraARG} -b" # equal to --build=any,all|--build=binary
+else
+    dpkgExtraARG="${dpkgExtraARG} --build=any"
+fi
+
+# Build package and set distributions it supports
 cd /home/builder/workspace/packaging
-dpkg-buildpackage -us -uc -b
-changestool /home/builder/workspace/*.changes setdistribution ${VERSIONS}
+dpkg-buildpackage ${dpkgExtraARG}
+changestool /home/builder/workspace/*.changes setdistribution ${debVersionList}
 
 # Copy resulting files into mounted directory where artifacts should be placed.
 mv /home/builder/workspace/*.{deb,changes,buildinfo} /home/builder/out

--- a/linux/jdk/redhat/build.gradle
+++ b/linux/jdk/redhat/build.gradle
@@ -55,6 +55,7 @@ task packageJdkRedHat {
 	def product = getProduct()
 	def productVersion = getProductVersion()
 	def gpgKey = getGPGKey()
+	def arch = getArch()
 
 	def outputDir = new File(project.buildDir.absolutePath, "ospackage")
 	outputs.dir(outputDir)
@@ -89,7 +90,10 @@ task packageJdkRedHat {
 
 		project.exec {
 			workingDir getRootDir()
-			commandLine "docker", "run", "--rm",
+			commandLine "docker", "run",
+				"--rm",
+				"-e", "buildArch=${arch}",
+				"-e", "buildVersion=${productVersion}",
 				"--mount", "type=bind,source=${buildDir},target=/home/builder/build",
 				"--mount", "type=bind,source=${outputDir.absolutePath},target=/home/builder/out",
 				"adoptium-packages-linux-jdk-redhat:latest"
@@ -109,15 +113,14 @@ task checkJdkRedHat(type: Test) {
 	def product = getProduct()
 	def productVersion = getProductVersion()
 	def gpgKey = getGPGKey()
-
-
+	def arch = getArch()
 	
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
 		println "We set the gpgkey!"
 	}
-
+	environment "testArch", "$arch"
 	useJUnitPlatform()
 	testLogging {
 		events "passed", "skipped", "failed"

--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -4,16 +4,22 @@ set -euxo pipefail
 # Ensure necessary directories for rpmbuild operation are present.
 rpmdev-setuptree
 
-# Build all spec files we can find
-targets="x86_64 ppc64le s390x aarch64 armv7hl"
+echo "DEBUG: building RH arch ${buildArch} with jdk version ${buildVersion}"
+# Build specified target or build all (not s390x on jdk8)
+if [ "${buildArch}" != "all" ]; then
+	targets=${buildArch}
+elif [ "${buildVersion}" != "8" ]; then
+	targets="x86_64 ppc64le aarch64 armv7hl s390x"
+else
+	targets="x86_64 ppc64le aarch64 armv7hl"
+fi
+
+# loop spec file originally from src/main/packaging/$product/$productVersion/*.spec
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 	spectool -g -R "$spec";
-	rpmbuild --nodeps -bs "$spec";
-	if [[ "$spec" =~ "temurin-8-jdk" ]]; then
-		targets="x86_64 ppc64le aarch64 armv7hl"
-	fi
+	rpmbuild --nodeps -bs "$spec"; # build src.rpm
 	for target in $targets; do
-		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
+		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm; # build binary package from src.rpm
 	done;
 done;
 

--- a/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
@@ -53,27 +53,30 @@ class DnfOperationsTest {
 			result = runShell(container, "dnf update -y");
 			assertThat(result.getExitCode()).isEqualTo(0);
 
-			result = runShell(container, "dnf install -y " + containerRpm);
-			assertThat(result.getExitCode()).isEqualTo(0);
-
-			result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
-			assertThat(result.getExitCode()).isEqualTo(0);
-			if (System.getenv("JDKGPG") != null) {
-				assertThat(result.getStdout())
-					.contains("Name        : " + System.getenv("PACKAGE"))
-					.contains("Group       : java")
-					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : RSA/SHA256,")
-					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
-			} else {
-				assertThat(result.getStdout())
-					.contains("Name        : " + System.getenv("PACKAGE"))
-					.contains("Group       : java")
-					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : (none)")
-					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			// below part: only test x86_64 rpm package in docker container
+			if (System.getenv("testArch") == "x86_64" || System.getenv("testArch") == "all") {
+				result = runShell(container, "dnf install -y " + containerRpm);
+				assertThat(result.getExitCode()).isEqualTo(0);
+	
+				result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
+				assertThat(result.getExitCode()).isEqualTo(0);
+				if (System.getenv("JDKGPG") != null) {
+					assertThat(result.getStdout())
+						.contains("Name        : " + System.getenv("PACKAGE"))
+						.contains("Group       : java")
+						.contains("License     : GPLv2 with exceptions")
+						.contains("Signature   : RSA/SHA256,")
+						.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+						.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+				} else {
+					assertThat(result.getStdout())
+						.contains("Name        : " + System.getenv("PACKAGE"))
+						.contains("Group       : java")
+						.contains("License     : GPLv2 with exceptions")
+						.contains("Signature   : (none)")
+						.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+						.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+				}
 			}
 		}
 	}

--- a/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithDnf.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithDnf.java
@@ -38,6 +38,9 @@ public class RedHatFlavoursWithDnf implements ArgumentsProvider {
 		 * Rocky Linux (CentOS replacement): All supported versions
 		 * Oracle Linux: All supported versions until premier support runs out
 		 *     (https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf)
+		 * Amazon Linux2 does not support DNF but only Yum
+		 * ubi7 does not have DNF pre-installed, ubi-minimal has microdnf
+		 * ubi8 has DNF installed
 		 */
 		return Stream.of(
 			Arguments.of("rockylinux", "8"),

--- a/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithYum.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithYum.java
@@ -46,9 +46,7 @@ public class RedHatFlavoursWithYum implements ArgumentsProvider {
 			Arguments.of("amazonlinux", "2"),
 			Arguments.of("centos", "7"),
 			Arguments.of("registry.access.redhat.com/ubi7/ubi", "latest"),
-			Arguments.of("redhat/ubi8", "latest"),
-			Arguments.of("oraclelinux", "7"),
-			Arguments.of("oraclelinux", "8")
+			Arguments.of("oraclelinux", "7")
 		);
 	}
 }

--- a/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithYum.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithYum.java
@@ -46,7 +46,9 @@ public class RedHatFlavoursWithYum implements ArgumentsProvider {
 			Arguments.of("amazonlinux", "2"),
 			Arguments.of("centos", "7"),
 			Arguments.of("registry.access.redhat.com/ubi7/ubi", "latest"),
-			Arguments.of("oraclelinux", "7")
+			Arguments.of("redhat/ubi8", "latest"),
+			Arguments.of("oraclelinux", "7"),
+			Arguments.of("oraclelinux", "8")
 		);
 	}
 }

--- a/linux/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
@@ -22,6 +22,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
 /**
  * Utility methods to interact with rpm files.
@@ -34,7 +35,14 @@ final class RpmFiles {
 	}
 
 	static Path hostRpmPath() {
-		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.x86_64.rpm");
+		// convert filter when build with ARCH == all
+		Map<String, String> env  = System.getenv(); 
+        for (String envName : env.keySet()) { 
+            System.out.format("%s = %s%n", envName, env.get(envName)); 
+        } 
+
+		String rpmFilter = System.getenv("testArch").equals("all") ? System.getenv("PACKAGE") + "*.x86_64.rpm" : System.getenv("PACKAGE") + "*." + System.getenv("testArch") + ".rpm";
+		return findBuildOutputOnHost(rpmFilter);
 	}
 
 	private static Path findBuildOutputOnHost(String pattern) {

--- a/linux/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/RpmFiles.java
@@ -37,9 +37,9 @@ final class RpmFiles {
 	static Path hostRpmPath() {
 		// convert filter when build with ARCH == all
 		Map<String, String> env  = System.getenv(); 
-        for (String envName : env.keySet()) { 
-            System.out.format("%s = %s%n", envName, env.get(envName)); 
-        } 
+        for (String envName : env.keySet()) {
+			System.out.format("%s = %s%n", envName, env.get(envName)); 
+        }
 
 		String rpmFilter = System.getenv("testArch").equals("all") ? System.getenv("PACKAGE") + "*.x86_64.rpm" : System.getenv("PACKAGE") + "*." + System.getenv("testArch") + ".rpm";
 		return findBuildOutputOnHost(rpmFilter);

--- a/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
@@ -54,27 +54,30 @@ class YumOperationsTest {
 			result = runShell(container, "yum update -y");
 			assertThat(result.getExitCode()).isEqualTo(0);
 
-			result = runShell(container, "yum install -y " + containerRpm);
-			assertThat(result.getExitCode()).isEqualTo(0);
+			// below part: only test x86_64 rpm package in docker container
+			if (System.getenv("testArch") == "x86_64" || System.getenv("testArch") == "all") {
+				result = runShell(container, "yum install -y " + containerRpm);
+				assertThat(result.getExitCode()).isEqualTo(0);
 
-			result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
-			assertThat(result.getExitCode()).isEqualTo(0);
-			if (System.getenv("JDKGPG") != null) {
-				assertThat(result.getStdout())
-					.contains("Name        : " + System.getenv("PACKAGE"))
-					.contains("Group       : java")
-					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : RSA/SHA256,")
-					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
-			} else {
-				assertThat(result.getStdout())
-					.contains("Name        : " + System.getenv("PACKAGE"))
-					.contains("Group       : java")
-					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : (none)")
-					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+				result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
+				assertThat(result.getExitCode()).isEqualTo(0);
+				if (System.getenv("JDKGPG") != null) {
+					assertThat(result.getStdout())
+						.contains("Name        : " + System.getenv("PACKAGE"))
+						.contains("Group       : java")
+						.contains("License     : GPLv2 with exceptions")
+						.contains("Signature   : RSA/SHA256,")
+						.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+						.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+				} else {
+					assertThat(result.getStdout())
+						.contains("Name        : " + System.getenv("PACKAGE"))
+						.contains("Group       : java")
+						.contains("License     : GPLv2 with exceptions")
+						.contains("Signature   : (none)")
+						.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+						.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+				}
 			}
 		}
 	}

--- a/linux/jdk/suse/build.gradle
+++ b/linux/jdk/suse/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 ext {
-	junitVersion = "5.7.0"
-	testcontainersVersion = "1.15.1"
-	assertjCoreVersion = "3.18.1"
+	junitVersion = "5.9.0"
+	testcontainersVersion = "1.17.3"
+	assertjCoreVersion = "3.23.1"
 }
 
 repositories {
@@ -58,6 +58,7 @@ task packageJdkSuse {
 	def product = getProduct()
 	def productVersion = getProductVersion()
 	def gpgKey = getGPGKey()
+	def arch = getArch()
 
 	doLast {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
@@ -87,10 +88,12 @@ task packageJdkSuse {
 			}			
 		}
 
-
 		project.exec {
 			workingDir getRootDir()
-			commandLine "docker", "run", "--rm",
+			commandLine "docker", "run",
+				"--rm",
+				"-e", "buildArch=${arch}",
+				"-e", "buildVersion=${productVersion}",
 				"--mount", "type=bind,source=${buildDir},target=/home/builder/build",
 				"--mount", "type=bind,source=${outputDir.absolutePath},target=/home/builder/out",
 				"adoptium-packages-linux-jdk-suse:latest"
@@ -110,13 +113,14 @@ task checkJdkSuse(type: Test) {
 	def product = getProduct()
 	def productVersion = getProductVersion()
 	def gpgKey = getGPGKey()
+	def arch = getArch()
 
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
 		println "We set the gpgkey!"
 	}
-	
+	environment "testArch", "$arch"
 	useJUnitPlatform()
 	testLogging {
 		events "passed", "skipped", "failed"

--- a/linux/jdk/suse/src/main/packaging/build.sh
+++ b/linux/jdk/suse/src/main/packaging/build.sh
@@ -4,15 +4,19 @@ set -euxo pipefail
 # Ensure necessary directories for rpmbuild operation are present.
 rpmdev-setuptree
 
-# Build all spec files we can find.
+echo "DEBUG: building Suse arch ${buildArch} with version ${buildVersion}"
+# Build specified target or build all (not s390x on jdk8)
+if [ "${buildArch}" != "all" ]; then
+	targets=${buildArch}
+elif [ ${buildVersion} != "8" ]; then
+	targets="x86_64 ppc64le aarch64 armv7hl s390x"
+else
+	targets="x86_64 ppc64le aarch64 armv7hl"
+fi
 
-targets="x86_64 ppc64le s390x aarch64 armv7hl"
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 	rpmdev-spectool -g -R "$spec";
 	rpmbuild --nodeps -bs "$spec";
-	if [[ "$spec" =~ "temurin-8-jdk" ]]; then
-		targets="x86_64 ppc64le aarch64 armv7hl"
-	fi
 	for target in $targets; do
 		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
 	done;

--- a/linux/jdk/suse/src/packageTest/java/packaging/RpmFiles.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/RpmFiles.java
@@ -34,11 +34,19 @@ final class RpmFiles {
 	}
 
 	static Path hostRpmPath() {
-		return findBuildOutputOnHost(System.getenv("PACKAGE") + "*.x86_64.rpm");
+		// convert filter when build with ARCH == all, only test on x86_64
+		String rpmFilter = "";
+		if (System.getenv("testArch").equals("all")) {
+			rpmFilter = System.getenv("PACKAGE") + "*.x86_64.rpm";
+		} else {
+			rpmFilter = System.getenv("PACKAGE") + "*." + System.getenv("testArch") + ".rpm";
+		}
+		System.out.println(rpmFilter);
+		return findBuildOutputOnHost(rpmFilter);
 	}
 
 	private static Path findBuildOutputOnHost(String pattern) {
-		Path outputDirectory = Paths.get("build", "ospackage");
+		Path outputDirectory = Paths.get("build", "ospackage"); // same as in container /home/builder/out
 		try (DirectoryStream<Path> stream = Files.newDirectoryStream(outputDirectory, pattern)) {
 			for (Path candidateFile : stream) {
 				return candidateFile;

--- a/linux/settings.gradle
+++ b/linux/settings.gradle
@@ -3,7 +3,6 @@ rootProject.name = "adoptium-packages-linux"
 include "ca-certificates",
 	"ca-certificates:debian",
 	"jdk",
-	"jdk:alpine",
 	"jdk:debian",
 	"jdk:redhat",
 	"jdk:suse"


### PR DESCRIPTION
   
            - add  support ARCH with selection but not include "all" 
            - remove support VERSION with value "all"
            - make DISTRO to only "all" "Debian" "RedHat" and "Suse"
            - pass in jdkversion as variable for rpm
            -  default use node pool "dockerBuild&&linux&&x64", debian non x64 use pool "docker&&linux&&${ARCH}"
            - change from matrix to three different stages per each distro
            - enable DOCKER_BUILDKIT on all even for Debian+s390x
            - only do git clone "installer.git" once and stash folder "linux" into different distro build stage
            - remove rpm for Centos8 publish to jfrog (already have rocky8)
            - add support in jenkins for 
               -  enableDebug for more build info
               -  split UPLOAD into "uploadPackage" and "uploadSRCRPM"
               -  can use the same job for test repo or branch (for debug purpose)
               -  add simple description of arch and distro per each job history
               -  set timeout to 2hr
               - 
![Screenshot from 2022-06-28 09-04-46](https://user-images.githubusercontent.com/915053/176115203-8d0dcdc5-9875-45a2-bb9c-76c5b98eb3bc.png)

           - add more test coverage:
              - missing test on oraclelinux8, ubi8
              - previous in one batch of bulding all RedHat/Suse RPMs, only test on x86_64
              - now at least one testcase per each arch, if rpm exists after build and keep "yum/dnf/zypper install" only on x86_64(same as before) due to docker host is for x64 only
Test run logs:
RedHat arm32:
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/125/console

RedHat x64:
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/129/console

Suse x86:
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/127/console

Suse aarch64
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/128/console

Suse all
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/136/console

RedHat all
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/139/console

Debian x64
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/138/console

Debian arm64
https://ci.adoptopenjdk.net/view/work-in-progress/job/Sophia-adoptium-packages-linux-pipeline/140/console

Ref: https://github.com/adoptium/installer/issues/459