### PR TITLE
refact: move build.sh as file not generate everytime in docker build

### DIFF
--- a/linux/ca-certificates/debian/build.gradle
+++ b/linux/ca-certificates/debian/build.gradle
@@ -61,7 +61,7 @@ task packageDebian {
 	dependsOn "assemble"
 
 	group = "packaging"
-	description = "Creates deb package for Debian flavours."
+	description = "Creates ca-certificate deb package for Debian flavours."
 
 	def outputDir = new File(project.buildDir.absolutePath, "ospackage")
 	outputs.dir(outputDir)
@@ -93,7 +93,7 @@ task packageDebian {
 task checkDebianPackage(type: Test) {
 	dependsOn packageDebian
 
-	description = 'Tests the generated Debian packages.'
+	description = 'Tests the generated ca-certificate Debian packages.'
 	group = 'verification'
 
 	testClassesDirs = sourceSets.packageTest.output.classesDirs

--- a/linux/ca-certificates/debian/src/main/packaging/Dockerfile
+++ b/linux/ca-certificates/debian/src/main/packaging/Dockerfile
@@ -2,32 +2,16 @@ FROM debian:buster
 
 # Combine apt-get update with apt-get install to prevent stale package indexes.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
- 		debhelper sudo lsb-release reprepro gosu tini
+ 		debhelper lsb-release reprepro gosu tini
 
 # Create unprivileged user for building, see
 # https://github.com/hexops/dockerfile#use-a-static-uid-and-gid
-RUN groupadd -g 10001 builder
-RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
+RUN groupadd -g 10001 builder \
+	&& useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
-RUN printf '#!/usr/bin/env bash\n\
-set -euxo pipefail\n\
-\n\
-# Copy build scripts into a directory within the container. Avoids polluting the mounted\n\
-# directory and permission errors.\n\
-mkdir /home/builder/workspace\n\
-cp -R /home/builder/build/generated/packaging /home/builder/workspace\n\
-\n\
-# Build package and set distributions it supports.\n\
-cd /home/builder/workspace/packaging\n\
-dpkg-buildpackage -us -uc -b\n\
-changestool /home/builder/workspace/*.changes setdistribution $VERSIONS\n\
-\n\
-# Copy resulting files into mounted directory where artifacts should be placed.\n\
-mv /home/builder/workspace/*.{deb,changes,buildinfo} /home/builder/out\n\
-'\
->> /home/builder/build.sh
+ADD build.sh /home/builder/build.sh
 RUN chmod +x /home/builder/build.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/entrypoint.sh" ]

--- a/linux/ca-certificates/debian/src/main/packaging/build.sh
+++ b/linux/ca-certificates/debian/src/main/packaging/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Copy build scripts into a directory within the container. Avoids polluting the mounted
+# directory and permission errors
+mkdir /home/builder/workspace
+cp -R /home/builder/build/generated/packaging /home/builder/workspace
+
+# Build package and set distributions it supports
+cd /home/builder/workspace/packaging
+dpkg-buildpackage -us -uc -b
+changestool /home/builder/workspace/*.changes setdistribution $VERSIONS
+
+# Copy resulting files into mounted directory where artifacts should be placed.
+mv /home/builder/workspace/*.{deb,changes,buildinfo} /home/builder/out

--- a/linux/gradlew
+++ b/linux/gradlew
@@ -126,7 +126,7 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin or MSYS, switch paths to Windows format before running java
+# For Cygwin or MSYS/mingw, switch paths to Windows format before running java
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`

--- a/linux/jdk/debian/src/main/packaging/Dockerfile
+++ b/linux/jdk/debian/src/main/packaging/Dockerfile
@@ -2,33 +2,32 @@ FROM debian:buster
 
 # Combine apt-get update with apt-get install to prevent stale package indexes.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
- 		debhelper sudo lsb-release reprepro gosu java-common libasound2 libc6 libx11-6 \
- 		libfontconfig1 libfreetype6 libxext6 libxi6 libxrender1 libxtst6 zlib1g tini wget
+		debhelper \
+		lsb-release \
+		reprepro \
+		gosu \
+		java-common \
+		libasound2 \
+		libc6 \
+		libx11-6 \
+		libfontconfig1 \
+		libfreetype6 \
+		libxext6 \
+		libxi6 \
+		libxrender1 \
+		libxtst6 \
+		zlib1g \
+		tini \
+		wget
 
 # Create unprivileged user for building, see
 # https://github.com/hexops/dockerfile#use-a-static-uid-and-gid
-RUN groupadd -g 10001 builder
-RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
+RUN groupadd -g 10001 builder \
+	&& useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
-RUN printf '#!/usr/bin/env bash\n\
-set -euxo pipefail\n\
-\n\
-# Copy build scripts into a directory within the container. Avoids polluting the mounted\n\
-# directory and permission errors.\n\
-mkdir /home/builder/workspace\n\
-cp -R /home/builder/build/generated/packaging /home/builder/workspace\n\
-\n\
-# Build package and set distributions it supports.\n\
-cd /home/builder/workspace/packaging\n\
-dpkg-buildpackage -us -uc -b\n\
-changestool /home/builder/workspace/*.changes setdistribution $VERSIONS\n\
-\n\
-# Copy resulting files into mounted directory where artifacts should be placed.\n\
-mv /home/builder/workspace/*.{deb,changes,buildinfo} /home/builder/out\n\
-'\
->> /home/builder/build.sh
+ADD build.sh /home/builder/build.sh
 RUN chmod +x /home/builder/build.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/entrypoint.sh" ]

--- a/linux/jdk/debian/src/main/packaging/build.sh
+++ b/linux/jdk/debian/src/main/packaging/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Copy build scripts into a directory within the container. Avoids polluting the mounted
+# directory and permission errors.
+mkdir /home/builder/workspace
+cp -R /home/builder/build/generated/packaging /home/builder/workspace
+
+# Build package and set distributions it supports.
+# $VERSIONS are container env. variables
+cd /home/builder/workspace/packaging
+dpkg-buildpackage -us -uc -b
+changestool /home/builder/workspace/*.changes setdistribution ${VERSIONS}
+
+# Copy resulting files into mounted directory where artifacts should be placed.
+mv /home/builder/workspace/*.{deb,changes,buildinfo} /home/builder/out

--- a/linux/jdk/redhat/src/main/packaging/Dockerfile
+++ b/linux/jdk/redhat/src/main/packaging/Dockerfile
@@ -1,25 +1,26 @@
 FROM fedora:33
 
-RUN dnf update -y && dnf install -y rpmdevtools rpm-sign rpmlint gnupg2 wget tar dpkg findutils
+RUN dnf update -y && dnf install -y rpmdevtools \
+	rpm-sign \
+	rpmlint \
+	gnupg2 \
+	wget \
+	tar \
+	dpkg \
+	findutils \
+	tini
 
-RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
-RUN gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu
-RUN chmod +x /usr/bin/gosu
-RUN rm -f /tmp/gosu.asc
-
-RUN wget --progress=dot:mega -O /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-RUN wget --progress=dot:mega -O /tmp/tini.asc https://github.com/krallin/tini/releases/download/v0.19.0/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
-RUN gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
-RUN gpg --batch --verify /tmp/tini.asc /usr/bin/tini
-RUN chmod +x /usr/bin/tini
-RUN rm -f /tmp/tini.asc
+RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+	&& wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc \
+	&& gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu \
+	&& chmod +x /usr/bin/gosu \
+	&& rm -f /tmp/gosu.asc
 
 # Create unprivileged user for building, see
 # https://github.com/hexops/dockerfile#use-a-static-uid-and-gid
-RUN groupadd -g 10001 builder
-RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
+RUN groupadd -g 10001 builder \
+	&& useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Add GPG key
 USER builder
@@ -32,37 +33,11 @@ RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg \
 '\
 >> /home/builder/.rpmmacros; \
 	fi
-USER root
 
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
-RUN printf '#!/usr/bin/env bash\n\
-set -euxo pipefail\n\
-\n\
-# Ensure necessary directories for rpmbuild operation are present.\n\
-rpmdev-setuptree \n\
-\n\
-# Build all spec files we can fin.\n\
-targets="x86_64 ppc64le s390x aarch64 armv7hl" \n\
-for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
-	spectool -g -R "$spec";\n\
-	rpmbuild --nodeps -bs "$spec"; \n\
-	if [[ "$spec" =~ "temurin-8-jdk" ]]; then \n\
-		targets="x86_64 ppc64le aarch64 armv7hl" \n\
-	fi \n\
-	for target in $targets; do \n\
-		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;\n\
-	done;\n\
-done;\n\
-\n\
-# Copy generated SRPMS, RPMs to destination folder\n\
-find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
-# Sign generated RPMs with rpmsign.\n\
-if grep -q %%_gpg_name /home/builder/.rpmmacros; then \n\
-	rpmsign --addsign /home/builder/out/*.rpm \n\
-fi;\n\
-'\
->> /home/builder/build.sh
+ADD build.sh /home/builder/build.sh
+USER root
 RUN chmod +x /home/builder/build.sh
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/entrypoint.sh" ]

--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Ensure necessary directories for rpmbuild operation are present.
+rpmdev-setuptree
+
+# Build all spec files we can find
+targets="x86_64 ppc64le s390x aarch64 armv7hl"
+for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
+	spectool -g -R "$spec";
+	rpmbuild --nodeps -bs "$spec";
+	if [[ "$spec" =~ "temurin-8-jdk" ]]; then
+		targets="x86_64 ppc64le aarch64 armv7hl"
+	fi
+	for target in $targets; do
+		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
+	done;
+done;
+
+# Copy generated SRPMS, RPMs to destination folder
+find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
+# Sign generated RPMs with rpmsign.
+if grep -q %%_gpg_name /home/builder/.rpmmacros; then
+	rpmsign --addsign /home/builder/out/*.rpm
+fi;

--- a/linux/jdk/suse/src/main/packaging/Dockerfile
+++ b/linux/jdk/suse/src/main/packaging/Dockerfile
@@ -1,18 +1,27 @@
 FROM opensuse/leap:15.2
 
-RUN zypper update -y && zypper install -y rpm-build rpm-devel rpmdevtools rpmlint gpg2 wget tar dpkg findutils tini
+RUN zypper update -y && zypper install -y rpm-build \
+	rpm-devel \
+	rpmdevtools \
+	rpmlint \
+	gpg2 \
+	wget \
+	tar \
+	dpkg \
+	findutils \
+	tini
 
-RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-RUN wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc
-RUN gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu
-RUN chmod +x /usr/bin/gosu
-RUN rm -f /tmp/gosu.asc
+RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+	&& wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc \
+	&& gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu \
+	&& chmod +x /usr/bin/gosu \
+	&& rm -f /tmp/gosu.asc
 
 # Create unprivileged user for building, see
 # https://github.com/hexops/dockerfile#use-a-static-uid-and-gid
-RUN groupadd -g 10001 builder
-RUN useradd -m -d /home/builder -u 10000 -g 10001 builder
+RUN groupadd -g 10001 builder \
+	&& useradd -m -d /home/builder -u 10000 -g 10001 builder
 
 # Add GPG key
 USER builder
@@ -25,38 +34,11 @@ RUN --mount=type=secret,id=gpg,gid=10001,uid=10000,dst=/tmp/private.gpg \
 '\
 >> /home/builder/.rpmmacros; \
 	fi
-USER root
 
 # Prepare entrypoint and build scripts
 ADD entrypoint.sh /entrypoint.sh
-RUN printf '#!/usr/bin/env bash\n\
-set -euxo pipefail\n\
-\n\
-# Ensure necessary directories for rpmbuild operation are present.\n\
-rpmdev-setuptree \n\
-\n\
-# Build all spec files we can find.\n\
-
-targets="x86_64 ppc64le s390x aarch64 armv7hl" \n\
-for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do\n\
-	rpmdev-spectool -g -R "$spec";\n\
-	rpmbuild --nodeps -bs "$spec"; \n\
-	if [[ "$spec" =~ "temurin-8-jdk" ]]; then \n\
-		targets="x86_64 ppc64le aarch64 armv7hl" \n\
-	fi \n\
-	for target in $targets; do \n\
-		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;\n\
-	done;\n\
-done;\n\
-\n\
-# Copy generated RPMs to destination folder\n\
-find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out\n\
-# Sign generated RPMs with rpmsign.\n\
-if grep -q %%_gpg_name /home/builder/.rpmmacros; then \n\
-	rpmsign --addsign /home/builder/out/*.rpm \n\
-fi;\n\
-'\
->> /home/builder/build.sh
+ADD build.sh /home/builder/build.sh
+USER root
 RUN chmod +x /home/builder/build.sh
 
 ENTRYPOINT ["/tini", "--", "/bin/bash", "/entrypoint.sh" ]

--- a/linux/jdk/suse/src/main/packaging/build.sh
+++ b/linux/jdk/suse/src/main/packaging/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Ensure necessary directories for rpmbuild operation are present.
+rpmdev-setuptree
+
+# Build all spec files we can find.
+
+targets="x86_64 ppc64le s390x aarch64 armv7hl"
+for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
+	rpmdev-spectool -g -R "$spec";
+	rpmbuild --nodeps -bs "$spec";
+	if [[ "$spec" =~ "temurin-8-jdk" ]]; then
+		targets="x86_64 ppc64le aarch64 armv7hl"
+	fi
+	for target in $targets; do
+		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
+	done;
+done;
+
+# Copy generated RPMs to destination folder
+find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
+# Sign generated RPMs with rpmsign
+if grep -q %%_gpg_name /home/builder/.rpmmacros; then
+	rpmsign --addsign /home/builder/out/*.rpm
+fi;


### PR DESCRIPTION
	- for better practice and to reduce maintenance work: create build.sh as static file not generate as step in docker build 
	- install tini from dnf not download from github
	- remove install "sudo" in dockerfile