### PR TITLE
linuxNew add support for Fedora 36

### DIFF
--- a/linuxNew/Jenkinsfile
+++ b/linuxNew/Jenkinsfile
@@ -204,6 +204,7 @@ def uploadRPMArtifacts(distro) {
             'rpm/rhel/8',
             'rpm/fedora/34',
             'rpm/fedora/35',
+            'rpm/fedora/36',
             'rpm/oraclelinux/8',
             'rpm/amazonlinux/2',
             'rpm/oraclelinux/7'

--- a/linuxNew/README.md
+++ b/linuxNew/README.md
@@ -165,6 +165,7 @@ Supported JDK version 8,11,17. Supported platform x86_64, aarch64, armv7hl, ppc6
 | centos/8 (switch to rocky/8)  | x86_64     ||   |
 | rpm/fedora/34    | x86_64     |                |
 | rpm/fedora/35    | x86_64     |                |
+| rpm/fedora/36    | x86_64     |                |
 | oraclelinux/7    | x86_64     |                |
 | oraclelinux/8    | x86_64     |                |
 | opensuse/15.1    | x86_64     |                |

--- a/linuxNew/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithDnf.java
+++ b/linuxNew/jdk/redhat/src/packageTest/java/packaging/RedHatFlavoursWithDnf.java
@@ -43,6 +43,7 @@ public class RedHatFlavoursWithDnf implements ArgumentsProvider {
 			Arguments.of("rockylinux", "8"),
 			Arguments.of("fedora", "34"),
 			Arguments.of("fedora", "35"),
+			Arguments.of("fedora", "36"),
 			Arguments.of("redhat/ubi8", "latest"),
 			Arguments.of("oraclelinux", "8")
 		);


### PR DESCRIPTION
Add the latest version of Fedora to the installer matrix.

Fixes #465 