### PR TITLE
Correct the priority of temurin-17-jdk and temurin-18-jdk & Remove jaotc and rmid from jvm tools.

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -2,7 +2,7 @@
 
 pkg_name = temurin-17-jdk
 priority = 1711
-jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver jexec jspawnhelper
+jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
 amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz
 amd64_checksum = 81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73
 arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 pkg_name = temurin-17-jdk
-priority = 1161
+priority = 1711
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver jexec jspawnhelper
 amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz
 amd64_checksum = 81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73

--- a/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 pkg_name = temurin-18-jdk
-priority = 1161
+priority = 1811
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver jexec jspawnhelper
 amd64_tarball_url = https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_linux_hotspot_18.0.1_10.tar.gz
 amd64_checksum = 16b1d9d75f22c157af04a1fd9c664324c7f4b5163c022b382a2f2e8897c1b0a2

--- a/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
@@ -2,7 +2,7 @@
 
 pkg_name = temurin-18-jdk
 priority = 1811
-jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmid rmiregistry serialver jexec jspawnhelper
+jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
 amd64_tarball_url = https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_linux_hotspot_18.0.1_10.tar.gz
 amd64_checksum = 16b1d9d75f22c157af04a1fd9c664324c7f4b5163c022b382a2f2e8897c1b0a2
 arm64_tarball_url = https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_aarch64_linux_hotspot_18.0.1_10.tar.gz


### PR DESCRIPTION
1. Change the priority of temurin-17-jdk to [1711](https://salsa.debian.org/openjdk-team/openjdk/-/blob/openjdk-17/debian/rules#L96) 
2. Change the priority of temurin-18-jdk to [1811](https://salsa.debian.org/openjdk-team/openjdk/-/blob/openjdk-18/debian/rules#L96)
3. Remove jaotc and rmid from jvm tools (JDK 17/18)
   1. [JEP 407: Remove RMI Activation](https://openjdk.org/jeps/407)
   2. [JEP 410: Remove the Experimental AOT and JIT Compiler](https://openjdk.org/jeps/410)