### PR TITLE
Update supported debian distributions

### DIFF
--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 /**
  * @author Andreas Ahlenstorf
+ * @author luozhenyu
  */
 public class DebianFlavours implements ArgumentsProvider {
 	@Override
@@ -36,10 +37,12 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "stretch"),
 			Arguments.of("debian", "buster"),
 			Arguments.of("debian", "bullseye"),
+			Arguments.of("debian", "bookworm"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "hirsute"),
-			Arguments.of("ubuntu", "jammy")
+			Arguments.of("ubuntu", "impish"),
+			Arguments.of("ubuntu", "jammy"),
+			Arguments.of("ubuntu", "kinetic")
 		);
 	}
 }


### PR DESCRIPTION
# Update supported debian distributions
> https://github.com/adoptium/installer/blob/master/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java#L32-L33
> Debian policy: Oldest, newest and development version.
> Ubuntu policy: Oldest LTS, newest LTS, and development version.

1. [Debian releases](https://wiki.debian.org/DebianReleases#Production_Releases)
    1. Add `debian:bookworm`
1. [Ubuntu releases](https://releases.ubuntu.com/)
    1. Remove `ubuntu:hirsute`
    1. Add `ubuntu:impish` and `ubuntu:kinetic`