### PR TITLE
Documentation: Docker 20.10+ is required to build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           export _JAVA_OPTIONS="-Xmx4G"
           export DOCKER_BUILDKIT=1
-          export COMPOSE_DOCKER_CLI_BUILD=1
           ./gradlew --parallel packageJdk${{ matrix.distro }} checkJdk${{ matrix.distro }} -PPRODUCT=${{ matrix.product.name }} -PPRODUCT_VERSION=${{ matrix.product.version }} --stacktrace
 
       - name: Relocate test results

--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ Repository for creating installable packages for Eclipse Adoptium based releases
 
 The packages are created using:
 1. [Wix Toolset](http://wixtoolset.org) (Windows), detail see [implementation](./wix)
-2. [Packages](http://s.sudre.free.fr/Software/Packages/about.html) (MacOS), detail see (implementation](./pkgbuild)
+2. [Packages](http://s.sudre.free.fr/Software/Packages/about.html) (MacOS), detail see [implementation](./pkgbuild)
 3. Linux installer include deb and rpm based package, detail see [implementation](./linux)
 
 The available packages can be seen from the Eclipse Temurin OpenJDK download page: https://adoptium.net/temurin/releases
 
-If a package is documented here but is not present on the Temurin OpenJDK download page, it may be because it is still being developed. Feel free to ask for the latest status in the installer Slack channel at [https://adoptopenjdk.slack.com].
+If a package is documented here but is not present on the Temurin OpenJDK download page, it may be because it is still being developed. Feel free to ask for the latest status in the installer Slack channel at <https://adoptopenjdk.slack.com>.
 
 See the [CONFIGURATION.md](./CONFIGURATION.md) file for the details of each package.
 
 ## Releasing Mac and Windows Installer packages
-Run from Jenkins job (Create Installer Mac][https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_mac/] and (Create Installer  Windows)[https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_windows/]
+Run from Jenkins job [Create Installer Mac](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_mac/) and [Create Installer  Windows](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/create_installer_windows/)
 
 ## Releasing Linux Installer packages
-During a Release the Linux installers (deb,rpm) are not created as part of the build job, but are instead created manually after the production binaries have been published to https://github.com/adoptium/temurinXX-binaries/releases.
+During a Release the Linux installers (deb,rpm) are not created as part of the build job, but are instead created manually after the production binaries have been published to `https://github.com/adoptium/temurin{XX}-binaries/releases`.
 The following documentation describes how to create and publish these Linux installers to [Artifactory](https://adoptium.jfrog.io/ui/repos/tree/General)
 
 1. Check the given jdk version binaries have been published to GitHub, "latest" should be for Temurin:
@@ -36,26 +36,26 @@ The following documentation describes how to create and publish these Linux inst
         - TAG: jdk8u292-b10
         - SUB_TAG: 8u292b10
     - When MAJOR_VERSION >= 11 && is Feature release:
-      - Hotspot jdk<MAJOR_VERSION>:
-        - VERSION: <MAJOR_VERSION>.0.0+<PRE-RLEASE_VERSION>
+      - Hotspot jdk\<MAJOR_VERSION>:
+        - VERSION: \<MAJOR_VERSION>.0.0+\<PRE-RLEASE_VERSION>
         - MAJOR_VERSION: <MAJOR_VERSION>
         - RELEASE_TYPE: Release
         - JVM: hotspot
-        - TAG: jdk-<MAJOR_VERSION>+<PRE-RLEASE_VERSION>
-        - SUB_TAG: <MAJOR_VERSION>_<PRE-RLEASE_VERSION>
+        - TAG: jdk-\<MAJOR_VERSION>+\<PRE-RLEASE_VERSION>
+        - SUB_TAG: \<MAJOR_VERSION>_\<PRE-RLEASE_VERSION>
     - When MAJOR_VERSION >= 11 && is CPU release:
-      - Hotspot jdk<MAJOR_VERSION>:
-        - VERSION: <MAJOR_VERSION>.<MINOR_VERSION>.<PATCH_VERSION>+<PRE-RLEASE_VERSION>
-        - MAJOR_VERSION: <MAJOR_VERSION>
+      - Hotspot jdk\<MAJOR_VERSION>:
+        - VERSION: \<MAJOR_VERSION>.\<MINOR_VERSION>.\<PATCH_VERSION>+\<PRE-RLEASE_VERSION>
+        - MAJOR_VERSION: \<MAJOR_VERSION>
         - RELEASE_TYPE: Release
         - JVM: hotspot
-        - TAG: jdk-<VERSION>
-        - SUB_TAG: <VERSION>
+        - TAG: jdk-\<VERSION>
+        - SUB_TAG: \<VERSION>
 3. After each Jenkins job run successfully, verify the artifacts have been uploaded to both [deb Artifactory](https://adoptium.jfrog.io/ui/repos/tree/General/deb/pool/main/t) and [rpm Artifactory](https://adoptium.jfrog.io/ui/repos/tree/General/rpm)
     - Verify:
       - For deb:
         - under sub-folder "temurin-<MAJOR_VERSION>"
-        - file "temurin-<MAJOR_VERSION>-jdk_*_<arch>.deb" exist, e.g temurin-18-jdk-18.0.1.0.0.10-1.armv7hl.rpm for jdk-18.0.1 hotspot JDK
+        - file "temurin-<MAJOR_VERSION>-jdk_*_\<arch>.deb" exist, e.g temurin-18-jdk-18.0.1.0.0.10-1.armv7hl.rpm for jdk-18.0.1 hotspot JDK
       - For rpm:
-        - under sub-folder "<distro>/<os_version>/<arch>/Packages/"
-        - file "temurin-<MAJOR_VERSION>-jdk-*.<arch>.rpm" exist, e.g: temurin-18-jdk-18.0.1.0.0.10-1.armv7hl.rpm for jdk-18.0.1 hotspot JDK
+        - under sub-folder "\<distro>/\<os_version>/\<arch>/Packages/"
+        - file "temurin-\<MAJOR_VERSION>-jdk-*.\<arch>.rpm" exist, e.g: temurin-18-jdk-18.0.1.0.0.10-1.armv7hl.rpm for jdk-18.0.1 hotspot JDK

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -135,7 +135,6 @@ def setup() {
     cleanWs()
     // Docker --mount option requires BuildKit
     env.DOCKER_BUILDKIT=1
-    env.COMPOSE_DOCKER_CLI_BUILD=1
     env._JAVA_OPTIONS="-Xmx4g"
     checkout scm
 }

--- a/linux/README.md
+++ b/linux/README.md
@@ -14,7 +14,7 @@ The default Adoptium package repository is https://packages.adoptium.net/ui/pack
 
 To run this locally
 
-* You will need to have Docker installed and running.
+* You will need to have Docker 20.10+ installed and running.
 * You will need to have Java 8+ installed.
 * You will need to have a minimum of 8GB of RAM on your system (the build required 4GB).
 
@@ -38,7 +38,6 @@ In all of the examples below you'll need to replace the following variables:
 
 ```shell
 export DOCKER_BUILDKIT=1
-export COMPOSE_DOCKER_CLI_BUILD=1
 export _JAVA_OPTIONS="-Xmx4g"
 ./gradlew clean package checkPackage -PPRODUCT=<vendor> -PPRODUCT_VERSION=<version>
 ```
@@ -62,7 +61,6 @@ _src/packageTest/java/packaging_ on them.
 
 ```shell
 export DOCKER_BUILDKIT=1
-export COMPOSE_DOCKER_CLI_BUILD=1
 export _JAVA_OPTIONS="-Xmx4g"
 ./gradlew clean packageJdkDebian checkJdkDebian --parallel -PPRODUCT=<vendor> -PPRODUCT_VERSION=<version>
 ```
@@ -74,7 +72,6 @@ export _JAVA_OPTIONS="-Xmx4g"
 
 ```shell
 export DOCKER_BUILDKIT=1
-export COMPOSE_DOCKER_CLI_BUILD=1
 export _JAVA_OPTIONS="-Xmx4g"
 ./gradlew clean packageJdkRedHat checkJdkRedHat --parallel -PPRODUCT=<vendor> -PPRODUCT_VERSION=<version>
 ```
@@ -85,8 +82,7 @@ export _JAVA_OPTIONS="-Xmx4g"
 - replace `<vendor>` with `temurin|dragonwell`
 
 ```shell
-export _JAVA_OPTIONS="-Xmx4g"
-export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
 export _JAVA_OPTIONS="-Xmx4g"
 ./gradlew clean packageJdkSuse checkJdkSuse --parallel -PPRODUCT=<vendor> -PPRODUCT_VERSION=<version>
 ```

--- a/linux/README.md
+++ b/linux/README.md
@@ -161,10 +161,12 @@ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
 
 ### DEB
 Supported JDK version 8,11,17,18 
+
 Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk11+)  
 
 ### RPM (RedHat and Suse)
 Supported JDK version 8,11,17,18
+
 Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk11+)
 SRPM also available.
 
@@ -189,4 +191,4 @@ SRPM also available.
 
 ## Install the packages
 
-See [Eclipse Temurin Linux (RPM/DEB) installer packages](https://blog.adoptium.net/2021/12/eclipse-temurin-linux-installers-available)
+See [Eclipse Temurin Linux (RPM/DEB) installer packages](https://adoptium.net/installation/linux/)


### PR DESCRIPTION
# Changes
1. Docker 20.10+ is required to build.
    1. Because the `--mount` option is used without specify experimental dockerfile `#syntax` directive. https://github.com/adoptium/installer/blob/master/linux/jdk/redhat/src/main/packaging/Dockerfile#L27
    > https://docs.docker.com/engine/release-notes/#20100
    > buildkit,dockerfile: Support for RUN --mount options without needing to specify experimental dockerfile #syntax directive. moby/buildkit#1717
2. Remove `COMPOSE_DOCKER_CLI_BUILD`
    1. Because docker compose is not used.
    2. Because `COMPOSE_DOCKER_CLI_BUILD=1` is the default setting. https://docs.docker.com/compose/reference/envvars/#compose_docker_cli_build