### PR TITLE
Correct jvm tools in JDK 17/18

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/jinfo.in
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/jinfo.in
@@ -3,7 +3,6 @@ alias=@pkg_alias@
 priority=@priority@
 section=contrib
 
-jdkhl jaotc /usr/lib/jvm/@jvm_dir@/bin/jaotc
 jdkhl jar /usr/lib/jvm/@jvm_dir@/bin/jar
 jdkhl jarsigner /usr/lib/jvm/@jvm_dir@/bin/jarsigner
 hl java /usr/lib/jvm/@jvm_dir@/bin/java
@@ -30,7 +29,6 @@ jdkhl jstack /usr/lib/jvm/@jvm_dir@/bin/jstack
 jdkhl jstat /usr/lib/jvm/@jvm_dir@/bin/jstat
 jdkhl jstatd /usr/lib/jvm/@jvm_dir@/bin/jstatd
 hl keytool /usr/lib/jvm/@jvm_dir@/bin/keytool
-hl rmid /usr/lib/jvm/@jvm_dir@/bin/rmid
 hl rmiregistry /usr/lib/jvm/@jvm_dir@/bin/rmiregistry
 jdkhl serialver /usr/lib/jvm/@jvm_dir@/bin/serialver
 hl jexec /usr/lib/jvm/@jvm_dir@/lib/jexec

--- a/linux/jdk/debian/src/main/packaging/temurin/18/debian/jinfo.in
+++ b/linux/jdk/debian/src/main/packaging/temurin/18/debian/jinfo.in
@@ -3,7 +3,6 @@ alias=@pkg_alias@
 priority=@priority@
 section=contrib
 
-jdkhl jaotc /usr/lib/jvm/@jvm_dir@/bin/jaotc
 jdkhl jar /usr/lib/jvm/@jvm_dir@/bin/jar
 jdkhl jarsigner /usr/lib/jvm/@jvm_dir@/bin/jarsigner
 hl java /usr/lib/jvm/@jvm_dir@/bin/java
@@ -29,8 +28,8 @@ jdkhl jshell /usr/lib/jvm/@jvm_dir@/bin/jshell
 jdkhl jstack /usr/lib/jvm/@jvm_dir@/bin/jstack
 jdkhl jstat /usr/lib/jvm/@jvm_dir@/bin/jstat
 jdkhl jstatd /usr/lib/jvm/@jvm_dir@/bin/jstatd
+jdkhl jwebserver /usr/lib/jvm/@jvm_dir@/bin/jwebserver
 hl keytool /usr/lib/jvm/@jvm_dir@/bin/keytool
-hl rmid /usr/lib/jvm/@jvm_dir@/bin/rmid
 hl rmiregistry /usr/lib/jvm/@jvm_dir@/bin/rmiregistry
 jdkhl serialver /usr/lib/jvm/@jvm_dir@/bin/serialver
 hl jexec /usr/lib/jvm/@jvm_dir@/lib/jexec

--- a/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/18/debian/rules
@@ -2,7 +2,7 @@
 
 pkg_name = temurin-18-jdk
 priority = 1811
-jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
+jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd jwebserver keytool rmiregistry serialver jexec jspawnhelper
 amd64_tarball_url = https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_linux_hotspot_18.0.1_10.tar.gz
 amd64_checksum = 16b1d9d75f22c157af04a1fd9c664324c7f4b5163c022b382a2f2e8897c1b0a2
 arm64_tarball_url = https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_aarch64_linux_hotspot_18.0.1_10.tar.gz

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -192,26 +192,18 @@ echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 if [ $1 -ge 1 ] ; then
     update-alternatives --install %{_bindir}/java java %{prefix}/bin/java %{priority} \
                         --slave %{_bindir}/jfr jfr %{prefix}/bin/jfr \
-                        --slave %{_bindir}/jjs jjs %{prefix}/bin/jjs \
                         --slave %{_bindir}/jrunscript jrunscript %{prefix}/bin/jrunscript \
                         --slave %{_bindir}/keytool keytool %{prefix}/bin/keytool \
-                        --slave %{_bindir}/pack200 pack200 %{prefix}/bin/pack200 \
-                        --slave %{_bindir}/rmid rmid %{prefix}/bin/rmid \
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry \
-                        --slave %{_bindir}/unpack200 unpack200 %{prefix}/bin/unpack200 \
                         --slave %{_bindir}/jexec jexec %{prefix}/lib/jexec \
                         --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \
                         --slave  %{_mandir}/man1/java.1 java.1 %{prefix}/man/man1/java.1 \
-                        --slave  %{_mandir}/man1/jjs.1 jjs.1 %{prefix}/man/man1/jjs.1 \
+                        --slave  %{_mandir}/man1/jfr.1 jfr.1 %{prefix}/man/man1/jfr.1 \
                         --slave  %{_mandir}/man1/jrunscript.1 jrunscript.1 %{prefix}/man/man1/jrunscript.1 \
                         --slave  %{_mandir}/man1/keytool.1 keytool.1 %{prefix}/man/man1/keytool.1 \
-                        --slave  %{_mandir}/man1/pack200.1 pack200.1 %{prefix}/man/man1/pack200.1 \
-                        --slave  %{_mandir}/man1/rmid.1 rmid.1 %{prefix}/man/man1/rmid.1 \
                         --slave  %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{prefix}/man/man1/rmiregistry.1 \
-                        --slave  %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 
     update-alternatives --install %{_bindir}/javac javac %{prefix}/bin/javac %{priority} \
-                        --slave %{_bindir}/jaotc jaotc %{prefix}/bin/jaotc \
                         --slave %{_bindir}/jar jar %{prefix}/bin/jar \
                         --slave %{_bindir}/jarsigner jarsigner %{prefix}/bin/jarsigner \
                         --slave %{_bindir}/javadoc javadoc %{prefix}/bin/javadoc \
@@ -227,12 +219,12 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/jlink jlink %{prefix}/bin/jlink \
                         --slave %{_bindir}/jmap jmap %{prefix}/bin/jmap \
                         --slave %{_bindir}/jmod jmod %{prefix}/bin/jmod \
+                        --slave %{_bindir}/jpackage jpackage %{prefix}/bin/jpackage \
                         --slave %{_bindir}/jps jps %{prefix}/bin/jps \
                         --slave %{_bindir}/jshell jshell %{prefix}/bin/jshell \
                         --slave %{_bindir}/jstack jstack %{prefix}/bin/jstack \
                         --slave %{_bindir}/jstat jstat %{prefix}/bin/jstat \
                         --slave %{_bindir}/jstatd jstatd %{prefix}/bin/jstatd \
-                        --slave %{_bindir}/rmic rmic %{prefix}/bin/rmic \
                         --slave %{_bindir}/serialver serialver %{prefix}/bin/serialver \
                         --slave  %{_mandir}/man1/jar.1 jar.1 %{prefix}/man/man1/jar.1 \
                         --slave  %{_mandir}/man1/jarsigner.1 jarsigner.1 %{prefix}/man/man1/jarsigner.1 \
@@ -242,14 +234,19 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/jcmd.1 jcmd.1 %{prefix}/man/man1/jcmd.1 \
                         --slave  %{_mandir}/man1/jconsole.1 jconsole.1 %{prefix}/man/man1/jconsole.1 \
                         --slave  %{_mandir}/man1/jdb.1 jdb.1 %{prefix}/man/man1/jdb.1 \
+                        --slave  %{_mandir}/man1/jdeprscan.1 jdeprscan.1 %{prefix}/man/man1/jdeprscan.1 \
                         --slave  %{_mandir}/man1/jdeps.1 jdeps.1 %{prefix}/man/man1/jdeps.1 \
+                        --slave  %{_mandir}/man1/jhsdb.1 jhsdb.1 %{prefix}/man/man1/jhsdb.1 \
                         --slave  %{_mandir}/man1/jinfo.1 jinfo.1 %{prefix}/man/man1/jinfo.1 \
+                        --slave  %{_mandir}/man1/jlink.1 jlink.1 %{prefix}/man/man1/jlink.1 \
                         --slave  %{_mandir}/man1/jmap.1 jmap.1 %{prefix}/man/man1/jmap.1 \
+                        --slave  %{_mandir}/man1/jmod.1 jmod.1 %{prefix}/man/man1/jmod.1 \
+                        --slave  %{_mandir}/man1/jpackage.1 jpackage.1 %{prefix}/man/man1/jpackage.1 \
                         --slave  %{_mandir}/man1/jps.1 jps.1 %{prefix}/man/man1/jps.1 \
+                        --slave  %{_mandir}/man1/jshell.1 jshell.1 %{prefix}/man/man1/jshell.1 \
                         --slave  %{_mandir}/man1/jstack.1 jstack.1 %{prefix}/man/man1/jstack.1 \
                         --slave  %{_mandir}/man1/jstat.1 jstat.1 %{prefix}/man/man1/jstat.1 \
                         --slave  %{_mandir}/man1/jstatd.1 jstatd.1 %{prefix}/man/man1/jstatd.1 \
-                        --slave  %{_mandir}/man1/rmic.1 rmic.1 %{prefix}/man/man1/rmic.1 \
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 

--- a/linux/jdk/redhat/src/main/packaging/temurin/18/temurin-18-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/18/temurin-18-jdk.spec
@@ -184,26 +184,18 @@ echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 if [ $1 -ge 1 ] ; then
     update-alternatives --install %{_bindir}/java java %{prefix}/bin/java %{priority} \
                         --slave %{_bindir}/jfr jfr %{prefix}/bin/jfr \
-                        --slave %{_bindir}/jjs jjs %{prefix}/bin/jjs \
                         --slave %{_bindir}/jrunscript jrunscript %{prefix}/bin/jrunscript \
                         --slave %{_bindir}/keytool keytool %{prefix}/bin/keytool \
-                        --slave %{_bindir}/pack200 pack200 %{prefix}/bin/pack200 \
-                        --slave %{_bindir}/rmid rmid %{prefix}/bin/rmid \
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry \
-                        --slave %{_bindir}/unpack200 unpack200 %{prefix}/bin/unpack200 \
                         --slave %{_bindir}/jexec jexec %{prefix}/lib/jexec \
                         --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \
                         --slave  %{_mandir}/man1/java.1 java.1 %{prefix}/man/man1/java.1 \
-                        --slave  %{_mandir}/man1/jjs.1 jjs.1 %{prefix}/man/man1/jjs.1 \
+                        --slave  %{_mandir}/man1/jfr.1 jfr.1 %{prefix}/man/man1/jfr.1 \
                         --slave  %{_mandir}/man1/jrunscript.1 jrunscript.1 %{prefix}/man/man1/jrunscript.1 \
                         --slave  %{_mandir}/man1/keytool.1 keytool.1 %{prefix}/man/man1/keytool.1 \
-                        --slave  %{_mandir}/man1/pack200.1 pack200.1 %{prefix}/man/man1/pack200.1 \
-                        --slave  %{_mandir}/man1/rmid.1 rmid.1 %{prefix}/man/man1/rmid.1 \
                         --slave  %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{prefix}/man/man1/rmiregistry.1 \
-                        --slave  %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 
     update-alternatives --install %{_bindir}/javac javac %{prefix}/bin/javac %{priority} \
-                        --slave %{_bindir}/jaotc jaotc %{prefix}/bin/jaotc \
                         --slave %{_bindir}/jar jar %{prefix}/bin/jar \
                         --slave %{_bindir}/jarsigner jarsigner %{prefix}/bin/jarsigner \
                         --slave %{_bindir}/javadoc javadoc %{prefix}/bin/javadoc \
@@ -219,12 +211,13 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/jlink jlink %{prefix}/bin/jlink \
                         --slave %{_bindir}/jmap jmap %{prefix}/bin/jmap \
                         --slave %{_bindir}/jmod jmod %{prefix}/bin/jmod \
+                        --slave %{_bindir}/jpackage jpackage %{prefix}/bin/jpackage \
                         --slave %{_bindir}/jps jps %{prefix}/bin/jps \
                         --slave %{_bindir}/jshell jshell %{prefix}/bin/jshell \
                         --slave %{_bindir}/jstack jstack %{prefix}/bin/jstack \
                         --slave %{_bindir}/jstat jstat %{prefix}/bin/jstat \
                         --slave %{_bindir}/jstatd jstatd %{prefix}/bin/jstatd \
-                        --slave %{_bindir}/rmic rmic %{prefix}/bin/rmic \
+                        --slave %{_bindir}/jwebserver jwebserver %{prefix}/bin/jwebserver \
                         --slave %{_bindir}/serialver serialver %{prefix}/bin/serialver \
                         --slave  %{_mandir}/man1/jar.1 jar.1 %{prefix}/man/man1/jar.1 \
                         --slave  %{_mandir}/man1/jarsigner.1 jarsigner.1 %{prefix}/man/man1/jarsigner.1 \
@@ -234,14 +227,20 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/jcmd.1 jcmd.1 %{prefix}/man/man1/jcmd.1 \
                         --slave  %{_mandir}/man1/jconsole.1 jconsole.1 %{prefix}/man/man1/jconsole.1 \
                         --slave  %{_mandir}/man1/jdb.1 jdb.1 %{prefix}/man/man1/jdb.1 \
+                        --slave  %{_mandir}/man1/jdeprscan.1 jdeprscan.1 %{prefix}/man/man1/jdeprscan.1 \
                         --slave  %{_mandir}/man1/jdeps.1 jdeps.1 %{prefix}/man/man1/jdeps.1 \
+                        --slave  %{_mandir}/man1/jhsdb.1 jhsdb.1 %{prefix}/man/man1/jhsdb.1 \
                         --slave  %{_mandir}/man1/jinfo.1 jinfo.1 %{prefix}/man/man1/jinfo.1 \
+                        --slave  %{_mandir}/man1/jlink.1 jlink.1 %{prefix}/man/man1/jlink.1 \
                         --slave  %{_mandir}/man1/jmap.1 jmap.1 %{prefix}/man/man1/jmap.1 \
+                        --slave  %{_mandir}/man1/jmod.1 jmod.1 %{prefix}/man/man1/jmod.1 \
+                        --slave  %{_mandir}/man1/jpackage.1 jpackage.1 %{prefix}/man/man1/jpackage.1 \
                         --slave  %{_mandir}/man1/jps.1 jps.1 %{prefix}/man/man1/jps.1 \
+                        --slave  %{_mandir}/man1/jshell.1 jshell.1 %{prefix}/man/man1/jshell.1 \
                         --slave  %{_mandir}/man1/jstack.1 jstack.1 %{prefix}/man/man1/jstack.1 \
                         --slave  %{_mandir}/man1/jstat.1 jstat.1 %{prefix}/man/man1/jstat.1 \
                         --slave  %{_mandir}/man1/jstatd.1 jstatd.1 %{prefix}/man/man1/jstatd.1 \
-                        --slave  %{_mandir}/man1/rmic.1 rmic.1 %{prefix}/man/man1/rmic.1 \
+                        --slave  %{_mandir}/man1/jwebserver.1 jwebserver.1 %{prefix}/man/man1/jwebserver.1 \
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -180,26 +180,18 @@ popd
 if [ $1 -ge 1 ] ; then
     update-alternatives --install %{_bindir}/java java %{prefix}/bin/java %{priority} \
                         --slave %{_bindir}/jfr jfr %{prefix}/bin/jfr \
-                        --slave %{_bindir}/jjs jjs %{prefix}/bin/jjs \
                         --slave %{_bindir}/jrunscript jrunscript %{prefix}/bin/jrunscript \
                         --slave %{_bindir}/keytool keytool %{prefix}/bin/keytool \
-                        --slave %{_bindir}/pack200 pack200 %{prefix}/bin/pack200 \
-                        --slave %{_bindir}/rmid rmid %{prefix}/bin/rmid \
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry \
-                        --slave %{_bindir}/unpack200 unpack200 %{prefix}/bin/unpack200 \
                         --slave %{_bindir}/jexec jexec %{prefix}/lib/jexec \
                         --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \
                         --slave  %{_mandir}/man1/java.1 java.1 %{prefix}/man/man1/java.1 \
-                        --slave  %{_mandir}/man1/jjs.1 jjs.1 %{prefix}/man/man1/jjs.1 \
+                        --slave  %{_mandir}/man1/jfr.1 jfr.1 %{prefix}/man/man1/jfr.1 \
                         --slave  %{_mandir}/man1/jrunscript.1 jrunscript.1 %{prefix}/man/man1/jrunscript.1 \
                         --slave  %{_mandir}/man1/keytool.1 keytool.1 %{prefix}/man/man1/keytool.1 \
-                        --slave  %{_mandir}/man1/pack200.1 pack200.1 %{prefix}/man/man1/pack200.1 \
-                        --slave  %{_mandir}/man1/rmid.1 rmid.1 %{prefix}/man/man1/rmid.1 \
                         --slave  %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{prefix}/man/man1/rmiregistry.1 \
-                        --slave  %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 
     update-alternatives --install %{_bindir}/javac javac %{prefix}/bin/javac %{priority} \
-                        --slave %{_bindir}/jaotc jaotc %{prefix}/bin/jaotc \
                         --slave %{_bindir}/jar jar %{prefix}/bin/jar \
                         --slave %{_bindir}/jarsigner jarsigner %{prefix}/bin/jarsigner \
                         --slave %{_bindir}/javadoc javadoc %{prefix}/bin/javadoc \
@@ -215,12 +207,12 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/jlink jlink %{prefix}/bin/jlink \
                         --slave %{_bindir}/jmap jmap %{prefix}/bin/jmap \
                         --slave %{_bindir}/jmod jmod %{prefix}/bin/jmod \
+                        --slave %{_bindir}/jpackage jpackage %{prefix}/bin/jpackage \
                         --slave %{_bindir}/jps jps %{prefix}/bin/jps \
                         --slave %{_bindir}/jshell jshell %{prefix}/bin/jshell \
                         --slave %{_bindir}/jstack jstack %{prefix}/bin/jstack \
                         --slave %{_bindir}/jstat jstat %{prefix}/bin/jstat \
                         --slave %{_bindir}/jstatd jstatd %{prefix}/bin/jstatd \
-                        --slave %{_bindir}/rmic rmic %{prefix}/bin/rmic \
                         --slave %{_bindir}/serialver serialver %{prefix}/bin/serialver \
                         --slave  %{_mandir}/man1/jar.1 jar.1 %{prefix}/man/man1/jar.1 \
                         --slave  %{_mandir}/man1/jarsigner.1 jarsigner.1 %{prefix}/man/man1/jarsigner.1 \
@@ -230,14 +222,19 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/jcmd.1 jcmd.1 %{prefix}/man/man1/jcmd.1 \
                         --slave  %{_mandir}/man1/jconsole.1 jconsole.1 %{prefix}/man/man1/jconsole.1 \
                         --slave  %{_mandir}/man1/jdb.1 jdb.1 %{prefix}/man/man1/jdb.1 \
+                        --slave  %{_mandir}/man1/jdeprscan.1 jdeprscan.1 %{prefix}/man/man1/jdeprscan.1 \
                         --slave  %{_mandir}/man1/jdeps.1 jdeps.1 %{prefix}/man/man1/jdeps.1 \
+                        --slave  %{_mandir}/man1/jhsdb.1 jhsdb.1 %{prefix}/man/man1/jhsdb.1 \
                         --slave  %{_mandir}/man1/jinfo.1 jinfo.1 %{prefix}/man/man1/jinfo.1 \
+                        --slave  %{_mandir}/man1/jlink.1 jlink.1 %{prefix}/man/man1/jlink.1 \
                         --slave  %{_mandir}/man1/jmap.1 jmap.1 %{prefix}/man/man1/jmap.1 \
+                        --slave  %{_mandir}/man1/jmod.1 jmod.1 %{prefix}/man/man1/jmod.1 \
+                        --slave  %{_mandir}/man1/jpackage.1 jpackage.1 %{prefix}/man/man1/jpackage.1 \
                         --slave  %{_mandir}/man1/jps.1 jps.1 %{prefix}/man/man1/jps.1 \
+                        --slave  %{_mandir}/man1/jshell.1 jshell.1 %{prefix}/man/man1/jshell.1 \
                         --slave  %{_mandir}/man1/jstack.1 jstack.1 %{prefix}/man/man1/jstack.1 \
                         --slave  %{_mandir}/man1/jstat.1 jstat.1 %{prefix}/man/man1/jstat.1 \
                         --slave  %{_mandir}/man1/jstatd.1 jstatd.1 %{prefix}/man/man1/jstatd.1 \
-                        --slave  %{_mandir}/man1/rmic.1 rmic.1 %{prefix}/man/man1/rmic.1 \
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 

--- a/linux/jdk/suse/src/main/packaging/temurin/18/temurin-18-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/18/temurin-18-jdk.spec
@@ -172,26 +172,18 @@ popd
 if [ $1 -ge 1 ] ; then
     update-alternatives --install %{_bindir}/java java %{prefix}/bin/java %{priority} \
                         --slave %{_bindir}/jfr jfr %{prefix}/bin/jfr \
-                        --slave %{_bindir}/jjs jjs %{prefix}/bin/jjs \
                         --slave %{_bindir}/jrunscript jrunscript %{prefix}/bin/jrunscript \
                         --slave %{_bindir}/keytool keytool %{prefix}/bin/keytool \
-                        --slave %{_bindir}/pack200 pack200 %{prefix}/bin/pack200 \
-                        --slave %{_bindir}/rmid rmid %{prefix}/bin/rmid \
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry \
-                        --slave %{_bindir}/unpack200 unpack200 %{prefix}/bin/unpack200 \
                         --slave %{_bindir}/jexec jexec %{prefix}/lib/jexec \
                         --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \
                         --slave  %{_mandir}/man1/java.1 java.1 %{prefix}/man/man1/java.1 \
-                        --slave  %{_mandir}/man1/jjs.1 jjs.1 %{prefix}/man/man1/jjs.1 \
+                        --slave  %{_mandir}/man1/jfr.1 jfr.1 %{prefix}/man/man1/jfr.1 \
                         --slave  %{_mandir}/man1/jrunscript.1 jrunscript.1 %{prefix}/man/man1/jrunscript.1 \
                         --slave  %{_mandir}/man1/keytool.1 keytool.1 %{prefix}/man/man1/keytool.1 \
-                        --slave  %{_mandir}/man1/pack200.1 pack200.1 %{prefix}/man/man1/pack200.1 \
-                        --slave  %{_mandir}/man1/rmid.1 rmid.1 %{prefix}/man/man1/rmid.1 \
                         --slave  %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{prefix}/man/man1/rmiregistry.1 \
-                        --slave  %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 
     update-alternatives --install %{_bindir}/javac javac %{prefix}/bin/javac %{priority} \
-                        --slave %{_bindir}/jaotc jaotc %{prefix}/bin/jaotc \
                         --slave %{_bindir}/jar jar %{prefix}/bin/jar \
                         --slave %{_bindir}/jarsigner jarsigner %{prefix}/bin/jarsigner \
                         --slave %{_bindir}/javadoc javadoc %{prefix}/bin/javadoc \
@@ -207,12 +199,13 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/jlink jlink %{prefix}/bin/jlink \
                         --slave %{_bindir}/jmap jmap %{prefix}/bin/jmap \
                         --slave %{_bindir}/jmod jmod %{prefix}/bin/jmod \
+                        --slave %{_bindir}/jpackage jpackage %{prefix}/bin/jpackage \
                         --slave %{_bindir}/jps jps %{prefix}/bin/jps \
                         --slave %{_bindir}/jshell jshell %{prefix}/bin/jshell \
                         --slave %{_bindir}/jstack jstack %{prefix}/bin/jstack \
                         --slave %{_bindir}/jstat jstat %{prefix}/bin/jstat \
                         --slave %{_bindir}/jstatd jstatd %{prefix}/bin/jstatd \
-                        --slave %{_bindir}/rmic rmic %{prefix}/bin/rmic \
+                        --slave %{_bindir}/jwebserver jwebserver %{prefix}/bin/jwebserver \
                         --slave %{_bindir}/serialver serialver %{prefix}/bin/serialver \
                         --slave  %{_mandir}/man1/jar.1 jar.1 %{prefix}/man/man1/jar.1 \
                         --slave  %{_mandir}/man1/jarsigner.1 jarsigner.1 %{prefix}/man/man1/jarsigner.1 \
@@ -222,14 +215,20 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/jcmd.1 jcmd.1 %{prefix}/man/man1/jcmd.1 \
                         --slave  %{_mandir}/man1/jconsole.1 jconsole.1 %{prefix}/man/man1/jconsole.1 \
                         --slave  %{_mandir}/man1/jdb.1 jdb.1 %{prefix}/man/man1/jdb.1 \
+                        --slave  %{_mandir}/man1/jdeprscan.1 jdeprscan.1 %{prefix}/man/man1/jdeprscan.1 \
                         --slave  %{_mandir}/man1/jdeps.1 jdeps.1 %{prefix}/man/man1/jdeps.1 \
+                        --slave  %{_mandir}/man1/jhsdb.1 jhsdb.1 %{prefix}/man/man1/jhsdb.1 \
                         --slave  %{_mandir}/man1/jinfo.1 jinfo.1 %{prefix}/man/man1/jinfo.1 \
+                        --slave  %{_mandir}/man1/jlink.1 jlink.1 %{prefix}/man/man1/jlink.1 \
                         --slave  %{_mandir}/man1/jmap.1 jmap.1 %{prefix}/man/man1/jmap.1 \
+                        --slave  %{_mandir}/man1/jmod.1 jmod.1 %{prefix}/man/man1/jmod.1 \
+                        --slave  %{_mandir}/man1/jpackage.1 jpackage.1 %{prefix}/man/man1/jpackage.1 \
                         --slave  %{_mandir}/man1/jps.1 jps.1 %{prefix}/man/man1/jps.1 \
+                        --slave  %{_mandir}/man1/jshell.1 jshell.1 %{prefix}/man/man1/jshell.1 \
                         --slave  %{_mandir}/man1/jstack.1 jstack.1 %{prefix}/man/man1/jstack.1 \
                         --slave  %{_mandir}/man1/jstat.1 jstat.1 %{prefix}/man/man1/jstat.1 \
                         --slave  %{_mandir}/man1/jstatd.1 jstatd.1 %{prefix}/man/man1/jstatd.1 \
-                        --slave  %{_mandir}/man1/rmic.1 rmic.1 %{prefix}/man/man1/rmic.1 \
+                        --slave  %{_mandir}/man1/jwebserver.1 jwebserver.1 %{prefix}/man/man1/jwebserver.1 \
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 


### PR DESCRIPTION
1. Remove jaotc, rmic, rmid, pack200, unpack200, jjs from jvm tools. (JDK 17/18)
    * [JEP 410: Remove the Experimental AOT and JIT Compiler](https://openjdk.org/jeps/410)
    * [JEP 407: Remove RMI Activation](https://openjdk.org/jeps/407)
    * [JEP 367: Remove the Pack200 Tools and API](https://openjdk.org/jeps/367)
    * [JEP 372: Remove the Nashorn JavaScript Engine](https://openjdk.org/jeps/372)
2. Add jwebserver into jvm tools. (JDK 18)
    * [Add jwebserver tool](https://bugs.openjdk.org/browse/JDK-8277460)
3. Add missing jvm tools for redhat/suse. (JDK 17/18)