### PR TITLE
Update supported suse distributions

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -210,9 +210,8 @@ def uploadRPMArtifacts(distro) {
             'rpm/oraclelinux/7'
         ],
         'suse'   : [
-            'rpm/opensuse/15.1',
-            'rpm/opensuse/15.2',
             'rpm/opensuse/15.3',
+            'rpm/opensuse/15.4',
             'rpm/sles/12',
             'rpm/sles/15'
         ]

--- a/linux/README.md
+++ b/linux/README.md
@@ -182,9 +182,8 @@ SRPM also available.
 | rpm/fedora/36    | x86_64     |                |
 | oraclelinux/7    | x86_64     |                |
 | oraclelinux/8    | x86_64     |                |
-| opensuse/15.1    | x86_64     |                |
-| opensuse/15.2    | x86_64     |                |
 | opensuse/15.3    | x86_64     |                |
+| opensuse/15.4    | x86_64     |                |
 | rocky/8          | x86_64     |                |
 | rpm/rhel/7       | x86_64     |                |
 | rpm/rhel/8       | x86_64     |                |

--- a/linux/jdk/suse/src/main/packaging/Dockerfile
+++ b/linux/jdk/suse/src/main/packaging/Dockerfile
@@ -1,18 +1,19 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.4
 
 RUN zypper update -y && zypper install -y rpm-build \
 	rpm-devel \
 	rpmdevtools \
 	rpmlint \
 	gpg2 \
+	dirmngr \
 	wget \
 	tar \
 	dpkg \
 	findutils \
 	tini
 
-RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-	&& wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.12/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc \
+RUN wget --progress=dot:mega -O /usr/bin/gosu https://github.com/tianon/gosu/releases/download/1.14/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+	&& wget --progress=dot:mega -O /tmp/gosu.asc https://github.com/tianon/gosu/releases/download/1.14/gosu-"$(dpkg --print-architecture | awk -F- '{ print $NF }')".asc \
 	&& gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu \
 	&& chmod +x /usr/bin/gosu \

--- a/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
@@ -35,9 +35,8 @@ public class SuseFlavours implements ArgumentsProvider {
 		 * SLES: All supported versions, see https://www.suse.com/lifecycle.
 		*/
 		return Stream.of(
-			Arguments.of("opensuse/leap", "15.1"),
-			Arguments.of("opensuse/leap", "15.2"),
 			Arguments.of("opensuse/leap", "15.3"),
+			Arguments.of("opensuse/leap", "15.4"),
 			Arguments.of("registry.suse.com/suse/sle15", "latest")
 		);
 	}


### PR DESCRIPTION
1. openSUSE Leap 15.1/15.2 have reached their end of life and should be removed. openSUSE Leap 15.4 is available.
    * https://en.opensuse.org/Lifetime