### PR TITLE
Update supported debian distributions

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -172,9 +172,9 @@ def uploadDebArtifacts(buildArch) {
         "s390x" : "s390x"
     ]
     def distro_list = ""
-    def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
+    def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
     deb_versions.each { distro ->
-        // Creates list like deb.distribution=stretch;deb.distribution=buster;
+        // Creates list like deb.distribution=bullseye;deb.distribution=bullseye;
         distro_list += "deb.distribution=${distro};"
     }
     def arch = archs.get(buildArch)

--- a/linux/README.md
+++ b/linux/README.md
@@ -167,6 +167,17 @@ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
 Supported JDK version 8,11,17,18 
 Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available for jdk11+)  
 
+| Distr        | Test enabled platforms | Note |
+|--------------|:----------------------:|:----:|
+| debian/12    |         x86_64         |      |
+| debian/11    |         x86_64         |      |
+| debian/10    |         x86_64         |      |   
+| ubuntu/22.10 |         x86_64         |      |
+| ubuntu/22.04 |         x86_64         |      |
+| ubuntu/21.10 |         x86_64         |      |
+| ubuntu/20.04 |         x86_64         |      |
+| ubuntu/18.04 |         x86_64         |      |
+
 ### RPM (RedHat and Suse)
 Supported JDK version 8,11,17,18
 Supported platform x86_64, aarch64, armv7hl, ppc64le, s390x (s390x is only available for jdk11+)

--- a/linux/ca-certificates/debian/build.gradle
+++ b/linux/ca-certificates/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
+def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linux/ca-certificates/debian/src/main/packaging/Dockerfile
+++ b/linux/ca-certificates/debian/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 # Combine apt-get update with apt-get install to prevent stale package indexes.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
@@ -37,6 +37,6 @@ class ChangesVerificationTest {
 		assertThat(changesFile).exists();
 
 		List<String> lines = Files.readAllLines(changesFile, StandardCharsets.UTF_8);
-		assertThat(lines).contains("Distribution: stretch buster bullseye bionic focal groovy hirsute jammy");
+		assertThat(lines).contains("Distribution: buster bullseye bionic focal impish jammy");
 	}
 }

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
@@ -30,16 +30,19 @@ public class DebianFlavours implements ArgumentsProvider {
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 		/*
 		 * Debian policy: Oldest, newest and development version.
+		 *     (https://www.debian.org/releases/)
 		 * Ubuntu policy: Oldest LTS, newest LTS, and development version.
+		 *     (https://wiki.ubuntu.com/Releases)
 		 */
 		return Stream.of(
-			Arguments.of("debian", "stretch"),
 			Arguments.of("debian", "buster"),
 			Arguments.of("debian", "bullseye"),
+			Arguments.of("debian", "bookworm"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "hirsute"),
-			Arguments.of("ubuntu", "jammy")
+			Arguments.of("ubuntu", "impish"),
+			Arguments.of("ubuntu", "jammy"),
+			Arguments.of("ubuntu", "kinetic")
 		);
 	}
 }

--- a/linux/jdk/debian/build.gradle
+++ b/linux/jdk/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["stretch", "buster", "bullseye", "bionic", "focal", "groovy", "hirsute", "jammy"]
+def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linux/jdk/debian/src/main/packaging/Dockerfile
+++ b/linux/jdk/debian/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 # Combine apt-get update with apt-get install to prevent stale package indexes.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \

--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -31,10 +31,11 @@ public class DebianFlavours implements ArgumentsProvider {
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 		/*
 		 * Debian policy: Oldest, newest and development version.
+		 *     (https://www.debian.org/releases/)
 		 * Ubuntu policy: Oldest LTS, newest LTS, and development version.
+		 *     (https://wiki.ubuntu.com/Releases)
 		 */
 		return Stream.of(
-			Arguments.of("debian", "stretch"),
 			Arguments.of("debian", "buster"),
 			Arguments.of("debian", "bullseye"),
 			Arguments.of("debian", "bookworm"),


### PR DESCRIPTION
1. Debian stretch has reached EOL.
    * https://wiki.debian.org/LTS
1. Ubuntu groovy, hirsute has reached EOL. Ubuntu impish is available. Ubuntu kinetic is available for testing.
    * https://wiki.ubuntu.com/Releases