### PR TITLE
remove impish from linux matrix

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -172,7 +172,7 @@ def uploadDebArtifacts(buildArch) {
         "s390x" : "s390x"
     ]
     def distro_list = ""
-    def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
+    def deb_versions = ["buster", "bullseye", "bionic", "focal", "jammy"]
     deb_versions.each { distro ->
         // Creates list like deb.distribution=bullseye;deb.distribution=bullseye;
         distro_list += "deb.distribution=${distro};"

--- a/linux/ca-certificates/debian/build.gradle
+++ b/linux/ca-certificates/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
+def deb_versions = ["buster", "bullseye", "bionic", "focal", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
@@ -37,6 +37,6 @@ class ChangesVerificationTest {
 		assertThat(changesFile).exists();
 
 		List<String> lines = Files.readAllLines(changesFile, StandardCharsets.UTF_8);
-		assertThat(lines).contains("Distribution: buster bullseye bionic focal impish jammy");
+		assertThat(lines).contains("Distribution: buster bullseye bionic focal jammy");
 	}
 }

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
@@ -40,7 +40,6 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "bookworm"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "impish"),
 			Arguments.of("ubuntu", "jammy"),
 			Arguments.of("ubuntu", "kinetic")
 		);

--- a/linux/jdk/debian/build.gradle
+++ b/linux/jdk/debian/build.gradle
@@ -24,7 +24,7 @@ version "1.0.0-SNAPSHOT"
  *
  * **Attention**: If you alter the list, check if the class DebianFlavours needs to be updated, too.
  */
-def deb_versions = ["buster", "bullseye", "bionic", "focal", "impish", "jammy"]
+def deb_versions = ["buster", "bullseye", "bionic", "focal", "jammy"]
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -41,7 +41,6 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "bookworm"),
 			Arguments.of("ubuntu", "bionic"),
 			Arguments.of("ubuntu", "focal"),
-			Arguments.of("ubuntu", "impish"),
 			Arguments.of("ubuntu", "jammy"),
 			Arguments.of("ubuntu", "kinetic")
 		);


### PR DESCRIPTION
Impish went EOL on 14th July (https://ubuntu.com/about/release-cycle)