### PR TITLE
fix: gpg sign issue on RPM

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -20,6 +20,6 @@ done;
 # Copy generated SRPMS, RPMs to destination folder
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign.
-if grep -q %%_gpg_name /home/builder/.rpmmacros; then
+if grep -q %_gpg_name /home/builder/.rpmmacros; then
 	rpmsign --addsign /home/builder/out/*.rpm
 fi;

--- a/linux/jdk/suse/src/main/packaging/build.sh
+++ b/linux/jdk/suse/src/main/packaging/build.sh
@@ -21,6 +21,6 @@ done;
 # Copy generated RPMs to destination folder
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign
-if grep -q %%_gpg_name /home/builder/.rpmmacros; then
+if grep -q %_gpg_name /home/builder/.rpmmacros; then
 	rpmsign --addsign /home/builder/out/*.rpm
 fi;


### PR DESCRIPTION
The bug was introduced when move the logic from Dockerfile to build.sh
which double %% is for syntax in Dockerfile so it need to be removed one in the build.sh

Ref: https://github.com/adoptium/adoptium/issues/152#issuecomment-1200800650 