### PR TITLE
Bump RPM spec files to version 2 in order to allow rebuild for signing

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.16.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.4.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.16.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global spec_version 17.0.4.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download


### PR DESCRIPTION
RPMs for 11.0.16+8 and 17.0.4+8 were published without being signed.
That issue is fixed by https://github.com/adoptium/installer/pull/509 and causes this problem:
```
Package temurin-17-jdk-17.0.4.0.0.8-1.aarch64.rpm is not signed
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: GPG check FAILED
```

This bumps the spec version so that we can republish in a way that means the the new fixed versions will be picked up by default.