### PR TITLE
Reset spec_release to 1 to avoid accidentally using 2 on next update

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.16.0.0.8
-%global spec_release 2
+%global spec_release 1
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.4.0.0.8
-%global spec_release 2
+%global spec_release 1
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.16.0.0.8
-%global spec_release 2
+%global spec_release 1
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global spec_version 17.0.4.0.0.8
-%global spec_release 2
+%global spec_release 1
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download


### PR DESCRIPTION
Resets the spec bump introduced in https://github.com/adoptium/installer/pull/510 in order to avoid anyone accidentally using `2` for the next quarterly release. Note that this needs general doc updates relating to installer rebuilds for all distros (Ref: #debian

Signed-off-by: Stewart X Addison <sxa@redhat.com>