### PR TITLE
test: update tests for checking if rpm is signed when we use -PGPG_KEY

### DIFF
--- a/linux/jdk/redhat/build.gradle
+++ b/linux/jdk/redhat/build.gradle
@@ -115,7 +115,7 @@ task checkJdkRedHat(type: Test) {
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
-		println "We set gpg!"
+		println "We set the gpgkey!"
 	}
 
 	useJUnitPlatform()

--- a/linux/jdk/redhat/build.gradle
+++ b/linux/jdk/redhat/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 ext {
-	junitVersion = "5.7.0"
-	testcontainersVersion = "1.15.1"
-	assertjCoreVersion = "3.18.1"
+	junitVersion = "5.9.0"
+	testcontainersVersion = "1.17.3"
+	assertjCoreVersion = "3.23.1"
 }
 
 repositories {
@@ -111,9 +111,11 @@ task checkJdkRedHat(type: Test) {
 	def gpgKey = getGPGKey()
 
 
+	
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
+		println "We set gpg!"
 	}
 
 	useJUnitPlatform()
@@ -125,9 +127,6 @@ task checkJdkRedHat(type: Test) {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
 			throw new IllegalArgumentException("Unknown product $product/$productVersion")
 		}
-		if (System.getenv().containsKey("JDKGPG")) {
-            println "We got gpg set!"
-        }
 	}
 }
 

--- a/linux/jdk/redhat/build.gradle
+++ b/linux/jdk/redhat/build.gradle
@@ -108,8 +108,13 @@ task checkJdkRedHat(type: Test) {
 
 	def product = getProduct()
 	def productVersion = getProductVersion()
+	def gpgKey = getGPGKey()
+
 
 	environment "PACKAGE", "$product-$productVersion-jdk"
+	if (gpgKey != null) {
+		environment "JDKGPG", "$gpgKey"
+	}
 
 	useJUnitPlatform()
 	testLogging {
@@ -120,6 +125,9 @@ task checkJdkRedHat(type: Test) {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
 			throw new IllegalArgumentException("Unknown product $product/$productVersion")
 		}
+		if (System.getenv().containsKey("JDKGPG")) {
+            println "We got gpg set!"
+        }
 	}
 }
 

--- a/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
@@ -63,7 +63,7 @@ class DnfOperationsTest {
 					.contains("Name        : " + System.getenv("PACKAGE"))
 					.contains("Group       : java")
 					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : RSA/SHA256")
+					.contains("Signature   : RSA/SHA256,")
 					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
 					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
 			} else {

--- a/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
@@ -58,12 +58,23 @@ class DnfOperationsTest {
 
 			result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
 			assertThat(result.getExitCode()).isEqualTo(0);
-			assertThat(result.getStdout())
-				.contains("Name        : " + System.getenv("PACKAGE"))
-				.contains("Group       : java")
-				.contains("License     : GPLv2 with exceptions")
-				.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-				.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			if (System.getenv("JDKGPG") != null) {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : RSA/SHA256")
+					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			} else {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : (none)")
+					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			}
 		}
 	}
 }

--- a/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
@@ -37,6 +37,7 @@ class YumOperationsTest {
 	@ParameterizedTest(name = "{0}:{1}")
 	@ArgumentsSource(RedHatFlavoursWithYum.class)
 	void packageSuccessfullyInstalled(String distribution, String codename) throws Exception {
+		
 		Path hostRpm = RpmFiles.hostRpmPath();
 
 		assertThat(hostRpm).exists();
@@ -63,7 +64,7 @@ class YumOperationsTest {
 					.contains("Name        : " + System.getenv("PACKAGE"))
 					.contains("Group       : java")
 					.contains("License     : GPLv2 with exceptions")
-					.contains("Signature   : RSA/SHA256")
+					.contains("Signature   : RSA/SHA256,")
 					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
 					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
 			} else {

--- a/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
@@ -58,12 +58,23 @@ class YumOperationsTest {
 
 			result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
 			assertThat(result.getExitCode()).isEqualTo(0);
-			assertThat(result.getStdout())
-				.contains("Name        : " + System.getenv("PACKAGE"))
-				.contains("Group       : java")
-				.contains("License     : GPLv2 with exceptions")
-				.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
-				.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			if (System.getenv("JDKGPG") != null) {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : RSA/SHA256")
+					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			} else {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : (none)")
+					.contains("Relocations : /usr/lib/jvm/" + System.getenv("PACKAGE"))
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			}
 		}
 	}
 }

--- a/linux/jdk/suse/build.gradle
+++ b/linux/jdk/suse/build.gradle
@@ -114,7 +114,7 @@ task checkJdkSuse(type: Test) {
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
-		println "We set gpg!"
+		println "We set the gpgkey!"
 	}
 	
 	useJUnitPlatform()

--- a/linux/jdk/suse/build.gradle
+++ b/linux/jdk/suse/build.gradle
@@ -114,8 +114,9 @@ task checkJdkSuse(type: Test) {
 	environment "PACKAGE", "$product-$productVersion-jdk"
 	if (gpgKey != null) {
 		environment "JDKGPG", "$gpgKey"
+		println "We set gpg!"
 	}
-
+	
 	useJUnitPlatform()
 	testLogging {
 		events "passed", "skipped", "failed"
@@ -125,9 +126,6 @@ task checkJdkSuse(type: Test) {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
 			throw new IllegalArgumentException("Unknown product $product/$productVersion")
 		}
-		if (System.getenv().containsKey("JDKGPG")) {
-            println "We got gpg set!"
-        }
 	}
 }
 

--- a/linux/jdk/suse/build.gradle
+++ b/linux/jdk/suse/build.gradle
@@ -112,7 +112,9 @@ task checkJdkSuse(type: Test) {
 	def gpgKey = getGPGKey()
 
 	environment "PACKAGE", "$product-$productVersion-jdk"
-	environment "GPG", "$gpgKey"
+	if (gpgKey != null) {
+		environment "JDKGPG", "$gpgKey"
+	}
 
 	useJUnitPlatform()
 	testLogging {
@@ -123,6 +125,9 @@ task checkJdkSuse(type: Test) {
 		if (!file("src/main/packaging/$product/$productVersion").exists()) {
 			throw new IllegalArgumentException("Unknown product $product/$productVersion")
 		}
+		if (System.getenv().containsKey("JDKGPG")) {
+            println "We got gpg set!"
+        }
 	}
 }
 

--- a/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
@@ -53,7 +53,7 @@ class ZypperOperationsTest {
 			result = runShell(container, "zypper update -y");
 			assertThat(result.getExitCode()).isEqualTo(0);
 			
-			if (System.getenv("GPG") != null) {
+			if (System.getenv("JDKGPG") != "null") {
 				// Signature verification failed [4-Signatures public key is not available]
 				result = runShell(container, "zypper --no-gpg-checks install -y " + containerRpm);
 			} else {
@@ -64,11 +64,21 @@ class ZypperOperationsTest {
 
 			result = runShell(container, "rpm -qi " + System.getenv("PACKAGE"));
 			assertThat(result.getExitCode()).isEqualTo(0);
-			assertThat(result.getStdout())
-				.contains("Name        : " + System.getenv("PACKAGE"))
-				.contains("Group       : java")
-				.contains("License     : GPLv2 with exceptions")
-				.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			if (System.getenv("JDKGPG") != null) {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : RSA/SHA256")
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			} else {
+				assertThat(result.getStdout())
+					.contains("Name        : " + System.getenv("PACKAGE"))
+					.contains("Group       : java")
+					.contains("License     : GPLv2 with exceptions")
+					.contains("Signature   : (none)")
+					.contains("Packager    : Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>");
+			}
 		}
 	}
 }

--- a/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
@@ -53,7 +53,7 @@ class ZypperOperationsTest {
 			result = runShell(container, "zypper update -y");
 			assertThat(result.getExitCode()).isEqualTo(0);
 			
-			if (System.getenv("JDKGPG") != "null") {
+			if (System.getenv("JDKGPG") != null) {
 				// Signature verification failed [4-Signatures public key is not available]
 				result = runShell(container, "zypper --no-gpg-checks install -y " + containerRpm);
 			} else {


### PR DESCRIPTION
- GHA test case without gpg
- https://ci.adoptopenjdk.net/job/Sophia-adoptium-packages-linux-pipeline/144/artifact/jdk/redhat/build/reports/tests/checkJdkRedHat/classes/packaging.DnfOperationsTest.html test case with -PGPG_KEY set : to have a negative debug to print assert `Signature   : RSA/SHA256, Wed Aug  3 15:13:10 2022, Key ID 843c48a565f8f04b` should be matched
- https://ci.adoptopenjdk.net/job/Sophia-adoptium-packages-linux-pipeline/143/ test cas with -PGPG_KEY set: to have a positive case
- uplift dependency version : most were released 1.5yrs ago to latest ones

Ref: https://github.com/adoptium/installer/issues/513