### PR TITLE
Update jdk8 installers to jdk8u345-b01

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,8 +1,8 @@
-temurin-8-jdk (8.0.332.0.0+9-1) UNRELEASED; urgency=medium
+temurin-8-jdk (8.0.345.0.0+1-1) STABLE; urgency=medium
 
-  * Eclipse Temurin 8.0.332.0.0+9 release.
+  * Eclipse Temurin 8.0.345.0.0+1 release.
 
- -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 5 May 2022 11:26:00 +0000
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 8 Aug 2022 11:26:00 +0000
 
 temurin-8-jdk (8.0.322.0.0+6-1) UNRELEASED; urgency=medium
 

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jdk
 priority = 1081
 # The list below must be kept in sync with the jinfo.in file 
 jvm_tools = appletviewer clhsdb extcheck hsdb idlj jar jarsigner java javac javadoc javah javap jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc jexec
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09.tar.gz
-amd64_checksum = adc13a0a0540d77f0a3481b48f10d61eb203e5ad4914507d489c2de3bd3d83da
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u332b09.tar.gz
-arm64_checksum = d10efb2afad3ed3d7bac9d3249cea77928aca6acb973cac0f90a2dd3606a3533
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u332b09.tar.gz
-armhf_checksum = c914250a736e620c12f9fe65fcd94ffa1acdacc5323e5aaff611a33a37cd158f
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u332b09.tar.gz
-ppc64el_checksum = 1df8c12fd97e76c388d64e4df16893f4285e000e6ff837d1e39969e5428aafa0
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz
+amd64_checksum = ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz
+arm64_checksum = c1965fb24dded7d7944e2da36cd902adf3b7b1d327aaa21ea507cff00a5a0090
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_arm_linux_hotspot_8u345b01.tar.gz
+armhf_checksum = af4ecd311df32b405142d5756f966418d0200fbf6cb9009c20a44dc691e8da6f
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u345b01.tar.gz
+ppc64el_checksum = f2be72678f6c2ad283453d0e21a6cb03144dda356e4edf79f818d99c37feaf34
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u332-b09-aarch32-20220420
+%global upstream_version 8u345-ga-aarch32-20220802
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -280,7 +280,7 @@ fi
 
 %changelog
 * Thu Aug 08 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.345.0.0.1.adopt0
-- Eclipse Temurin 8.0.332-b09 release.
+- Eclipse Temurin 8.0.345-b01 release.
 * Thu May 05 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.332.0.0.9.adopt0
 - Eclipse Temurin 8.0.332-b09 release.
 * Thu Feb 03 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.322.0.0.6-1.adopt0

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u332-b09
+%global upstream_version 8u345-b01
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.332.0.0.9
+%global spec_version 8.0.345.0.0.1
 %global spec_release 1
 %global priority 1081
 
@@ -279,6 +279,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Aug 08 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.345.0.0.1.adopt0
+- Eclipse Temurin 8.0.332-b09 release.
 * Thu May 05 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.332.0.0.9.adopt0
 - Eclipse Temurin 8.0.332-b09 release.
 * Thu Feb 03 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.322.0.0.6-1.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u332-b09
+%global upstream_version 8u345-b01
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.332.0.0.9
+%global spec_version 8.0.345.0.0.1
 %global spec_release 1
 %global priority 1081
 
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u332-b09-aarch32-20220420
+%global upstream_version 8u345-b01-aarch32-20220802
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u345-b01-aarch32-20220802
+%global upstream_version 8u345-ga-aarch32-20220802
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch


### PR DESCRIPTION
Updates for the new version. Cannot be used successfully until arm32 tarballs have been pushed.

Signed-off-by: Stewart X Addison <sxa@redhat.com>