### PR TITLE
configure dependabot to check for gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: "gradle" 
+  directory: "/linux" 
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This will keep the gradle dependencies updated