### PR TITLE
linux: remove unnecessary update commands

### DIFF
--- a/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/DnfOperationsTest.java
@@ -50,9 +50,6 @@ class DnfOperationsTest {
 
 			Container.ExecResult result;
 
-			result = runShell(container, "dnf update -y");
-			assertThat(result.getExitCode()).isEqualTo(0);
-
 			// below part: only test x86_64 rpm package in docker container
 			if (System.getenv("testArch") == "x86_64" || System.getenv("testArch") == "all") {
 				result = runShell(container, "dnf install -y " + containerRpm);

--- a/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
+++ b/linux/jdk/redhat/src/packageTest/java/packaging/YumOperationsTest.java
@@ -51,9 +51,6 @@ class YumOperationsTest {
 
 			Container.ExecResult result;
 
-			result = runShell(container, "yum update -y");
-			assertThat(result.getExitCode()).isEqualTo(0);
-
 			// below part: only test x86_64 rpm package in docker container
 			if (System.getenv("testArch") == "x86_64" || System.getenv("testArch") == "all") {
 				result = runShell(container, "yum install -y " + containerRpm);


### PR DESCRIPTION
the yum/dnf update commands take a long time and slow down the CI unnecessarily.