### PR TITLE
fix: wrong function name and target name

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -282,7 +282,7 @@ def uploadDebArtifacts(buildArch) {
     )
 }
 
-def uploadRPMArtifacts(DISTRO) {
+def uploadRpmArtifacts(DISTRO) {
     def distro_Package = [
         'redhat' : [
             'rpm/centos/7',

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -308,7 +308,7 @@ def uploadRpmArtifacts(DISTRO) {
     // full list of all platforms, up to user to opt out s390x+jdk8 from input
     def rpmArchList = [
         'x86_64' : 'x86_64',
-        'armv7l': 'armv7hl',
+        'armv7hl': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'

--- a/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/ZypperOperationsTest.java
@@ -49,9 +49,6 @@ class ZypperOperationsTest {
 
 			Container.ExecResult result;
 
-			result = runShell(container, "zypper update -y");
-			assertThat(result.getExitCode()).isEqualTo(0);
-
 			// below part: only test x86_64 rpm package in docker container
 			if (System.getenv("testArch") == "x86_64" || System.getenv("testArch") == "all") {
 				if (System.getenv("JDKGPG") != null) {


### PR DESCRIPTION
from https://github.com/adoptium/installer/commit/c2d0c59f57a7dc4b269eaca70f4adf0979630512
name was change from uploadRPMArtifacts to uploadRpmArtifacts


it should be ended in arm7hl not arm7l
which showed the same for Sep jdk19 release

remove zypper update test which fails very often and slow down release
https://github.com/adoptium/installer/issues/549