### PR TITLE
fix: add sleep and this fixed problem of error when upload

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -234,6 +234,7 @@ def uploadArtifacts(DISTRO, buildArch) {
 }
 
 def uploadAlpineArtifacts(buildArch) {
+    sleep 5
     rtUpload ( //artifactory plugin
         serverId: 'adoptium.jfrog.io',
         failNoOp: true,
@@ -268,7 +269,7 @@ def uploadDebArtifacts(buildArch) {
         // Creates list like deb.distribution=stretch;deb.distribution=buster;
         distro_list += "deb.distribution=${deb_version};"
     }
-
+    sleep 5
     rtUpload( //artifactory plugin
         serverId: 'adoptium.jfrog.io',
         failNoOp: true,
@@ -296,7 +297,7 @@ def uploadRpmArtifacts(DISTRO) {
             'rpm/fedora/36',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',
-            'rpm/amazonlinux/2',
+            'rpm/amazonlinux/2'
 
         ],
         'suse'   : [
@@ -320,10 +321,10 @@ def uploadRpmArtifacts(DISTRO) {
         rpmArchList.put('source', 'src')
     }
 
-    packageDirs.each {
-        packageDir ->
-            rpmArchList.each {
-                entry -> rtUpload(
+    packageDirs.each { packageDir ->
+            rpmArchList.each { entry ->
+                    sleep 5
+                    rtUpload(
                     serverId: 'adoptium.jfrog.io',
                     failNoOp: true,
                     spec: """{

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -234,6 +234,10 @@ def uploadArtifacts(DISTRO, buildArch) {
 }
 
 def uploadAlpineArtifacts(buildArch) {
+    /*
+        workaround for error when upload to artifactory: No files were affected in the upload process
+        might be caused by 1) slow response from artifactory server 2) archive just done by jenkins job
+    */
     sleep 5
     rtUpload ( //artifactory plugin
         serverId: 'adoptium.jfrog.io',
@@ -269,6 +273,10 @@ def uploadDebArtifacts(buildArch) {
         // Creates list like deb.distribution=stretch;deb.distribution=buster;
         distro_list += "deb.distribution=${deb_version};"
     }
+    /*
+        workaround for error when upload to artifactory: No files were affected in the upload process
+        might be caused by 1) slow response from artifactory server 2) archive just done by jenkins job
+    */
     sleep 5
     rtUpload( //artifactory plugin
         serverId: 'adoptium.jfrog.io',
@@ -323,6 +331,10 @@ def uploadRpmArtifacts(DISTRO) {
 
     packageDirs.each { packageDir ->
             rpmArchList.each { entry ->
+                /*
+                    workaround for error when upload to artifactory: No files were affected in the upload process
+                    might be caused by 1) slow response from artifactory server 2) archive just done by jenkins job
+                */
                     sleep 5
                     rtUpload(
                     serverId: 'adoptium.jfrog.io',


### PR DESCRIPTION
1. Add check(findFiles()) and sleep before upload for RPM(redhat suse) and Deb
to prevent - error: "No files were affected in the upload process" which  could be when build just done jenkins not find archived file
2. fix the missing logic, when only choose one arch for RPM it should only try to upload this arch not "all"

Below test1 and2  run failed because of packages already exist in jfrog so the overridden is not permitted but we do not see "No files were affected in the upload process" error any more
- Test1: only build suse jdk19 with ppc64
```
 Upload artifacts for 19 - ppc64le - Suse
[Pipeline] echo
Prepare for ppc64le.rpm
[Pipeline] findFiles
[Pipeline] rtUpload
Executing command: /bin/sh -c git log --pretty=format:%s -1
[consumer_0] Deploying artifact: https://adoptium.jfrog.io/artifactory/rpm/opensuse/15.3/ppc64le/Packages/temurin-19-jdk-19.0.1.0.0.10-1.ppc64le.rpm

```
- Test2: build suse jdk19 with "all" as arch
```
Archiving artifacts
[Pipeline] echo
Upload artifacts for 19 - all - Suse
[Pipeline] echo
Prepare for x86_64.rpm
[Pipeline] findFiles
[Pipeline] rtUpload
Executing command: /bin/sh -c git log --pretty=format:%s -1
[consumer_1] Deploying artifact: https://adoptium.jfrog.io/artifactory/rpm/opensuse/15.3/x86_64/Packages/temurin-19-jdk-19.0.1.0.0.10-1.x86_64.rpm
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // dir
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
```
Test3:  build deb x64 for jdk19

.....
```
Upload artifacts for 19 - x86_64 - Debian
[Pipeline] echo
Prepare for amd64.deb
[Pipeline] findFiles
[Pipeline] rtUpload
[consumer_0] Deploying artifact: https://adoptium.jfrog.io/artifactory/deb/pool/main/t/temurin-19/temurin-19-jdk_19.0.1.0.0%2B10_amd64.deb
[Pipeline] }
```
Fixes: https://github.com/adoptium/installer/issues/554