### PR TITLE
Fix dependency action hashes and restrict permissions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,9 @@ concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   check-ca-certificates:
     name: "Check ca-certificates"
@@ -21,9 +24,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
         with:
           java-version: '17'
           java-package: jdk
@@ -35,7 +38,7 @@ jobs:
           export _JAVA_OPTIONS="-Xmx4G"
           ./gradlew --parallel :ca-certificates:check --stacktrace
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         if: always() # always run even if the previous step fails
         with:
           name: test-results
@@ -60,9 +63,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
         with:
           java-version: '17'
           java-package: jdk
@@ -81,7 +84,7 @@ jobs:
           mkdir ${{ matrix.product.version }}
           mv jdk ${{ matrix.product.version }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         if: always() # always run even if the previous step fails
         with:
           name: test-results
@@ -92,5 +95,5 @@ jobs:
     name: "Validate Gradle Wrapper"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1.0.5

--- a/.github/workflows/pgkbuild.yml
+++ b/.github/workflows/pgkbuild.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
     - name: Install dependencies
       run: brew install --cask packages
 
     - name: Setup environment variables
-      uses: allenevans/set-env@v2.2.0
+      uses: allenevans/set-env@c4f231179ef63887be707202a295d9cb1c687eb9 # v2.2.0
       with:
         MAJOR_VERSION: 17
         FULL_VERSION: 17.0.3_7
@@ -39,7 +39,7 @@ jobs:
         export WORKSPACE=$PWD
         bash pkgbuild/create-installer-mac.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
       with:
         name: macOS_${{ matrix.architecture }}
         path: workspace/target/*.pkg

--- a/.github/workflows/wix.yml
+++ b/.github/workflows/wix.yml
@@ -40,14 +40,14 @@ jobs:
     name: wix
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Install dependencies
         run: |
           choco install --no-progress wget
 
       - name: Setup environment variables
-        uses: allenevans/set-env@v2.2.0
+        uses: allenevans/set-env@c4f231179ef63887be707202a295d9cb1c687eb9 # v2.2.0
         with:
           PRODUCT_MAJOR_VERSION: ${{ matrix.PRODUCT_MAJOR_VERSION }}
           PRODUCT_MINOR_VERSION: ${{ matrix.PRODUCT_MINOR_VERSION }}
@@ -88,7 +88,7 @@ jobs:
           call Build.OpenJDK_generic.cmd
         shell: cmd
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: windows
           path: wix/ReleaseDir/*.msi


### PR DESCRIPTION
Fix the GitHub action dependencies to specific version hashes, and ensure they have minimal permissions.
Part of https://github.com/adoptium/adoptium/issues/187