### PR TITLE
MSI for ARM64 Java should install in C:\Program Files, not C:\Program Files (Arm)

### DIFF
--- a/wix/Main.wxs.template
+++ b/wix/Main.wxs.template
@@ -55,7 +55,7 @@
             </Directory>
          </Directory>
     <?elseif $(env.Platform)=arm64?>
-        <Directory Id="ProgramFilesARMFolder" Name="Program Files (Arm)">
+        <Directory Id="ProgramFilesARMFolder">
             <Directory Id="PRODUCTMANUFACTURER" Name="$(var.ProductManufacturer)">
                 <Directory Id="INSTALLDIR" Name="$(var.AppFolder)" />
             </Directory>


### PR DESCRIPTION
See https://github.com/microsoft/openjdk/issues/344 for context