### PR TITLE
feat: add support for fedora 37

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -308,6 +308,7 @@ def uploadRpmArtifacts(DISTRO, rpmArch) {
             'rpm/rhel/9',
             'rpm/fedora/35',
             'rpm/fedora/36',
+            'rpm/fedora/37',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',
             'rpm/amazonlinux/2'


### PR DESCRIPTION
Seems we have updated README for fedora37 before it was officially released  but not enable it from the build.

Fixes: https://github.com/adoptium/installer/issues/566