### PR TITLE
get rid of %%pretrans since nothing uses it

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.17.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -184,9 +184,6 @@ popd
 %{__mkdir} -p %{buildroot}/usr/lib/tmpfiles.d
 echo 'x /tmp/hsperfdata_*' > "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
-
-%pretrans
-# noop
 
 %post
 if [ $1 -ge 1 ] ; then

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.5.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -184,9 +184,6 @@ popd
 %{__mkdir} -p %{buildroot}/usr/lib/tmpfiles.d
 echo 'x /tmp/hsperfdata_*' > "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
-
-%pretrans
-# noop
 
 %post
 if [ $1 -ge 1 ] ; then

--- a/linux/jdk/redhat/src/main/packaging/temurin/18/temurin-18-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/18/temurin-18-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 18.0.0.0.0___18.0.0.0.0+36
 #  18.0.0.0.0___36 == 18.0.0.0.0+36
 %global spec_version 18.0.2.1.0.1
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin18-binaries/releases/download
@@ -176,9 +176,6 @@ popd
 %{__mkdir} -p %{buildroot}/usr/lib/tmpfiles.d
 echo 'x /tmp/hsperfdata_*' > "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
-
-%pretrans
-# noop
 
 %post
 if [ $1 -ge 1 ] ; then

--- a/linux/jdk/redhat/src/main/packaging/temurin/19/temurin-19-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/19/temurin-19-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 19.0.0.0.0___19.0.0.0.0+36
 #  19.0.0.0.0___36 == 19.0.0.0.0+36
 %global spec_version 19.0.1.0.0.10
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin19-binaries/releases/download
@@ -176,9 +176,6 @@ popd
 %{__mkdir} -p %{buildroot}/usr/lib/tmpfiles.d
 echo 'x /tmp/hsperfdata_*' > "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
-
-%pretrans
-# noop
 
 %post
 if [ $1 -ge 1 ] ; then

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
 %global spec_version 8.0.352.0.0.8
-%global spec_release 1
+%global spec_release 2
 %global priority 1081
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -172,9 +172,6 @@ popd
 %{__mkdir} -p %{buildroot}/usr/lib/tmpfiles.d
 echo 'x /tmp/hsperfdata_*' > "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
 echo 'x /tmp/.java_pid*' >> "%{buildroot}/usr/lib/tmpfiles.d/%{name}.conf"
-
-%pretrans
-# noop
 
 %post
 if [ $1 -ge 1 ] ; then


### PR DESCRIPTION
I noticed this while attempting to determine why osbuild-composer bombs out because temurin-17-jdk dependencies seem to not be satisfied when osbuild's org.osbuild.rpm phase attempts to install packages in an empty build root.

The temurin jdk spec files have an empty %%pretrans section, meaning there isn't anything to be run in it, but that doesn't mean rpm would not try to process that section when starting the install transaction ;( This is because in an empty build root there is absolutely nothing yet installed.

In any case, it is severely discouraged to use %%pretrans at all and most up-to-date rpm documentation seem to prohibit its use with a shell interpreter.

Please see https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#pretrans and https://github.com/osbuild/osbuild-composer/issues/3197 and and https://bugzilla.redhat.com/show_bug.cgi?id=1683365 and and https://rpm-software-management.github.io/rpm/manual/lua

