### PR TITLE
Fix: jenkinsfile not take standard java syntax

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -248,7 +248,7 @@ def buildAndTest(String DISTRO, String buildArch) {
 def buildCLi(String DISTRO, String buildArch, String GPG_KEY = null) {
     def buildCLI = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
     if (GPG_KEY) {
-        buildCli += " -PGPG_KEY=${GPG_KEY}"
+        buildCLI += " -PGPG_KEY=${GPG_KEY}"
     }
     buildCLI = params.enableDebug.toBoolean() ? buildCLI + ' --stacktrace' : buildCLI
     sh("$buildCLI")

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -245,7 +245,7 @@ def buildAndTest(String DISTRO, String buildArch) {
     }
 }
 
-private void buildCLi(String DISTRO, String buildArch, String GPG_KEY = null) {
+def buildCLi(String DISTRO, String buildArch, String GPG_KEY = null) {
     def buildCLI = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
     if (GPG_KEY) {
         buildCli += " -PGPG_KEY=${GPG_KEY}"


### PR DESCRIPTION
see error from installer job:
`Exception in buildAndTest: groovy.lang.MissingPropertyException: No such property: buildCli for class: WorkflowScript`
