### PR TITLE
Fix: Update Spec Numbers For Signed RPM Re-Release

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.18.0.0.10
-%global spec_release 2
+%global spec_release 3
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -262,6 +262,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
+- Eclipse Temurin 11.0.18+10 release 3.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin 11.0.18+10 release.
 * Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.6.0.0.10
-%global spec_release 2
+%global spec_release 3
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -259,6 +259,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
+- Eclipse Temurin 17.0.6+10 release 3.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin 17.0.6+10 release.
 * Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0
@@ -270,6 +272,6 @@ fi
 * Wed Apr 27 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.3.0.0.7.adopt0
 - Eclipse Temurin 17.0.3+7 release.
 * Tue Feb 1 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.2.0.0.8-1.adopt0
-- Eclipse Temurin 17.0.2+8 release. 
+- Eclipse Temurin 17.0.2+8 release.
 * Fri Aug 13 2021 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.0.0.0.35-1.adopt0
 - Eclipse Temurin 17.0.0+35 release.

--- a/linux/jdk/redhat/src/main/packaging/temurin/19/temurin-19-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/19/temurin-19-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 19.0.0.0.0___19.0.0.0.0+36
 #  19.0.0.0.0___36 == 19.0.0.0.0+36
 %global spec_version 19.0.2.0.0.7
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin19-binaries/releases/download
@@ -253,6 +253,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
+- Eclipse Temurin 19.0.2+7 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
 - Eclipse Temurin 19.0.2+7 release.
 * Sat Nov 05 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.1.0.0.10.adopt0

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
 %global spec_version 8.0.362.0.0.9
-%global spec_release 1
+%global spec_release 2
 %global priority 1081
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -276,6 +276,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
+- Eclipse Temurin 8.0.362-b09 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
 - Eclipse Temurin 8.0.362-b09 release.
 * Thu Nov 03 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.352.0.0.8.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.18.0.0.10
-%global spec_release 1
+%global spec_release 2
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -253,6 +253,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
+- Eclipse Temurin 11.0.18+10 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin 11.0.18+10 release.
 * Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global spec_version 17.0.6.0.0.10
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -249,6 +249,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
+- Eclipse Temurin 17.0.6+10 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin 17.0.6+10 release.
 * Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/19/temurin-19-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/19/temurin-19-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 19.0.0.0.0___19.0.0.0.0+36
 #  19.0.0.0.0___36 == 19.0.0.0.0+36
 %global spec_version 19.0.2.0.0.7
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin19-binaries/releases/download
@@ -243,6 +243,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
+- Eclipse Temurin 19.0.2+7 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
 - Eclipse Temurin 19.0.2+7 release.
 * Sat Nov 05 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.1.0.0.10.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
 %global spec_version 8.0.362.0.0.9
-%global spec_release 1
+%global spec_release 2
 %global priority 1081
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -266,6 +266,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
+- Eclipse Temurin 8.0.362-b09 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
 - Eclipse Temurin 8.0.362-b09 release.
 * Thu Nov 03 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.352.0.0.8.adopt0

--- a/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.18.0.0.10
-%global spec_release 2
+%global spec_release 3
 %global priority 1112
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -198,5 +198,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
+- Eclipse Temurin 11.0.18+10 release 3.
 * Mon Jan 30 2023 11:35:00  Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin JRE 11.0.18+10 release.

--- a/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.6.0.0.10
-%global spec_release 2
+%global spec_release 3
 %global priority 1712
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -185,5 +185,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
+- Eclipse Temurin JRE 17.0.6+10 release 3.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin JRE 17.0.6+10 release.

--- a/linux/jre/redhat/src/main/packaging/temurin/19/temurin-19-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/19/temurin-19-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 19.0.0.0.0___19.0.0.0.0+36
 #  19.0.0.0.0___36 == 19.0.0.0.0+36
 %global spec_version 19.0.2.0.0.7
-%global spec_release 2
+%global spec_release 3
 %global priority 1912
 
 %global source_url_base https://github.com/adoptium/temurin19-binaries/releases/download
@@ -186,5 +186,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
+- Eclipse Temurin JRE 19.0.2+7 release 3.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
 - Eclipse Temurin JRE 19.0.2+7 release.

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
 %global spec_version 8.0.362.0.0.9
-%global spec_release 2
+%global spec_release 3
 %global priority 1082
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -191,5 +191,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
+- Eclipse Temurin 8.0.362-b09 release 3.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
 - Eclipse Temurin JRE 8.0.362-b09 release.

--- a/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
 %global spec_version 11.0.18.0.0.10
-%global spec_release 1
+%global spec_release 2
 %global priority 1112
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -189,5 +189,7 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
+- Eclipse Temurin JRE 11.0.18+10 release 2.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin JRE 11.0.18+10 release.

--- a/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
 %global spec_version 17.0.6.0.0.10
-%global spec_release 1
+%global spec_release 2
 %global priority 1712
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -175,5 +175,7 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
+- Eclipse Temurin JRE 17.0.6+10 release 2.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin JRE 17.0.6+10 release.

--- a/linux/jre/suse/src/main/packaging/temurin/19/temurin-19-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/19/temurin-19-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 19.0.0.0.0___19.0.0.0.0+36
 #  19.0.0.0.0___36 == 19.0.0.0.0+36
 %global spec_version 19.0.2.0.0.7
-%global spec_release 1
+%global spec_release 2
 %global priority 1912
 
 %global source_url_base https://github.com/adoptium/temurin19-binaries/releases/download
@@ -176,5 +176,7 @@ fi
 %{prefix}
 
 %changelog
+* Thu Feb 22 2023  Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
+- Eclipse Temurin JRE 19.0.2+7 release 2.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 19.0.2.0.0.7.adopt0
 - Eclipse Temurin JRE 19.0.2+7 release.

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
 %global spec_version 8.0.362.0.0.9
-%global spec_release 1
+%global spec_release 2
 %global priority 1082
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -181,6 +181,7 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
+- Eclipse Temurin 8.0.362-b09 release 2.
 * Mon Jan 30 2023 11:35:00 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9.adopt0
 - Eclipse Temurin JRE 8.0.362-b09 release.
-


### PR DESCRIPTION
 Update Spec Numbers For Signed RPM Re-Release, this is only required for RHEL / SUSE, as both APK and DEB packages do not get signed.