### PR TITLE
Add all files from source packages to target APK

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,6 @@
 name: Check Linux Packages
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'linux/**'

--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -23,7 +23,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jdk" # for the virtual package
+depends=""
 subpackages="$pkgname-src:_src:noarch
 	$pkgname-jdk:_jdk"
 source="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-$_pkgvername/OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
@@ -78,9 +78,15 @@ _jdk() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
 	mv "$_fromroot/include" "$_toroot"
+	mv "$_fromroot/jmods"   "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/man"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -9,7 +9,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 11"
 provider_priority=11
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -25,7 +25,7 @@ makedepends="
 "
 depends=""
 subpackages="$pkgname-src:_src:noarch
-	$pkgname-jdk:_jdk"
+	$pkgname-jdk:_jdk:x86_64"
 source="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-$_pkgvername/OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 
 	HelloWorld.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -9,7 +9,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 17"
 provider_priority=17
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -25,7 +25,7 @@ makedepends="
 "
 depends=""
 subpackages="$pkgname-src:_src:noarch
-	$pkgname-jdk:_jdk"
+	$pkgname-jdk:_jdk:x86_64"
 source="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$_pkgvername/OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 
 	HelloWorld.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -23,7 +23,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jdk" # for the virtual package
+depends=""
 subpackages="$pkgname-src:_src:noarch
 	$pkgname-jdk:_jdk"
 source="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$_pkgvername/OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
@@ -78,9 +78,15 @@ _jdk() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
 	mv "$_fromroot/include" "$_toroot"
+	mv "$_fromroot/jmods"   "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/man"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jdk/alpine/src/main/packaging/temurin/19/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/19/APKBUILD
@@ -11,7 +11,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 19"
 provider_priority=19
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -27,7 +27,7 @@ makedepends="
 "
 depends=""
 subpackages="$pkgname-src:_src:noarch
-	$pkgname-jdk:_jdk"
+	$pkgname-jdk:_jdk:x86_64"
 source="https://github.com/adoptium/temurin19-binaries/releases/download/jdk-$_pkgvername/OpenJDK19U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 
 	HelloWorld.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/19/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/19/APKBUILD
@@ -25,7 +25,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jdk" # for the virtual package
+depends=""
 subpackages="$pkgname-src:_src:noarch
 	$pkgname-jdk:_jdk"
 source="https://github.com/adoptium/temurin19-binaries/releases/download/jdk-$_pkgvername/OpenJDK19U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
@@ -80,9 +80,15 @@ _jdk() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
 	mv "$_fromroot/include" "$_toroot"
+	mv "$_fromroot/jmods"   "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/man"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jdk/alpine/src/main/packaging/temurin/20/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/20/APKBUILD
@@ -11,7 +11,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 20"
 provider_priority=20
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -25,9 +25,9 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jdk" # for the virtual package
+depends=""
 subpackages="$pkgname-src:_src:noarch
-	$pkgname-jdk:_jdk"
+	$pkgname-jdk:_jdk:x86_64"
 source="https://github.com/adoptium/20-binaries/releases/download/jdk-$_pkgvername/OpenJDK20U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 
 	HelloWorld.java
@@ -80,9 +80,15 @@ _jdk() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
 	mv "$_fromroot/include" "$_toroot"
+	mv "$_fromroot/jmods"   "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/man"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -23,7 +23,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jre" # for the virtual package
+depends=""
 subpackages="$pkgname-jre:_jre"
 source="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-$_pkgvername/OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
@@ -57,8 +57,13 @@ _jre() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/man"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -9,7 +9,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 11"
 provider_priority=11
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -24,7 +24,7 @@ makedepends="
 	libxtst-dev
 "
 depends=""
-subpackages="$pkgname-jre:_jre"
+subpackages="$pkgname-jre:_jre:x86_64"
 source="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-$_pkgvername/OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
 

--- a/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -23,7 +23,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jre" # for the virtual package
+depends=""
 subpackages="$pkgname-jre:_jre"
 source="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$_pkgvername/OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
@@ -57,8 +57,12 @@ _jre() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -9,7 +9,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 17"
 provider_priority=17
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -24,7 +24,7 @@ makedepends="
 	libxtst-dev
 "
 depends=""
-subpackages="$pkgname-jre:_jre"
+subpackages="$pkgname-jre:_jre:x86_64"
 source="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-$_pkgvername/OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
 

--- a/linux/jre/alpine/src/main/packaging/temurin/19/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/19/APKBUILD
@@ -11,7 +11,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 19"
 provider_priority=19
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -26,7 +26,7 @@ makedepends="
 	libxtst-dev
 "
 depends=""
-subpackages="$pkgname-jre:_jre"
+subpackages="$pkgname-jre:_jre:x86_64"
 source="https://github.com/adoptium/temurin19-binaries/releases/download/jdk-$_pkgvername/OpenJDK19U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
 

--- a/linux/jre/alpine/src/main/packaging/temurin/19/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/19/APKBUILD
@@ -25,7 +25,7 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jre" # for the virtual package
+depends=""
 subpackages="$pkgname-jre:_jre"
 source="https://github.com/adoptium/temurin19-binaries/releases/download/jdk-$_pkgvername/OpenJDK19U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
@@ -59,8 +59,12 @@ _jre() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"

--- a/linux/jre/alpine/src/main/packaging/temurin/20/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/20/APKBUILD
@@ -11,7 +11,7 @@ pkgrel=0
 pkgdesc="Eclipse Temurin 20"
 provider_priority=20
 url="https://adoptium.net"
-arch="x86_64"
+arch="noarch"
 license="GPL-2.0-with-classpath-exception"
 makedepends="
 	alsa-lib-dev
@@ -25,8 +25,8 @@ makedepends="
 	libxt-dev
 	libxtst-dev
 "
-depends="$pkgname-jre" # for the virtual package
-subpackages="$pkgname-jre:_jre"
+depends=""
+subpackages="$pkgname-jre:_jre:x86_64"
 source="https://github.com/adoptium/temurin20-binaries/releases/download/jdk-$_pkgvername/OpenJDK20U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "
 
@@ -59,8 +59,12 @@ _jre() {
 	_toroot="$subpkgdir/$_java_home"
 
 	mkdir -p "$_toroot"
-	mv "$_fromroot/bin" "$_toroot"
-	mv "$_fromroot/lib" "$_toroot"
+	mv "$_fromroot/bin"     "$_toroot"
+	mv "$_fromroot/conf"    "$_toroot"
+	mv "$_fromroot/legal"   "$_toroot"
+	mv "$_fromroot/lib"     "$_toroot"
+	mv "$_fromroot/release" "$_toroot"
+	mv "$_fromroot/NOTICE"  "$_toroot"
 
 	# symlink to shared cacerts store
 	rm "$_toroot/lib/security/cacerts"


### PR DESCRIPTION
Add all files from source packages to target APK  
and remove "virtual package" from dependencies as it is empty now.

Resolves #613 & #631 

Should be tested in the context of mercedes-benz/sechub#1794 // @Jeeppler + @ryanlewis