### PR TITLE
Fixed infrequent 'permission denied' bug

### DIFF
--- a/linux/jdk/debian/src/main/packaging/entrypoint.sh
+++ b/linux/jdk/debian/src/main/packaging/entrypoint.sh
@@ -7,6 +7,7 @@ set -euox pipefail
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.

--- a/linux/jdk/redhat/src/main/packaging/entrypoint.sh
+++ b/linux/jdk/redhat/src/main/packaging/entrypoint.sh
@@ -9,6 +9,7 @@ HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.

--- a/linux/jdk/suse/src/main/packaging/entrypoint.sh
+++ b/linux/jdk/suse/src/main/packaging/entrypoint.sh
@@ -9,6 +9,7 @@ HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.

--- a/linux/jre/debian/src/main/packaging/entrypoint.sh
+++ b/linux/jre/debian/src/main/packaging/entrypoint.sh
@@ -7,6 +7,7 @@ set -euox pipefail
 HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.

--- a/linux/jre/redhat/src/main/packaging/entrypoint.sh
+++ b/linux/jre/redhat/src/main/packaging/entrypoint.sh
@@ -9,6 +9,7 @@ HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.

--- a/linux/jre/suse/src/main/packaging/entrypoint.sh
+++ b/linux/jre/suse/src/main/packaging/entrypoint.sh
@@ -9,6 +9,7 @@ HOST_USER_GID=$(stat -c "%g" /home/builder/out)
 export GPG_TTY=$(tty)
 getent group "$HOST_USER_GID" || groupadd -g "$HOST_USER_GID" hostusrg
 usermod -a -G "$HOST_USER_GID" builder
+chown builder /home/builder/out
 chmod g+w /home/builder/out
 
 # Drop root privileges and build the package.


### PR DESCRIPTION
Fixed infrequent 'permission denied' bug when reading/writing to output folder for rpm or deb builds