### PR TITLE
Update Debian checksums for JRE8 / PPC64 LE & ARM32

### DIFF
--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
@@ -11,7 +11,7 @@ arm64_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b9
 armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_arm_linux_hotspot_8u372b07.tar.gz
 armhf_checksum = e58e017012838ae4f0db78293e3246cc09958e6ea9a2393c5947ec003bf736dd
 ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_ppc64le_linux_hotspot_8u372b07.tar.gz
-ppc64el_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b95
+ppc64el_checksum = ba5f8141a16722e39576bf42b69d2b8ebf95fc2c05441e3200f609af4dd9f1ea
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
@@ -9,7 +9,7 @@ amd64_checksum = b6fdfe32085a884c11b31f66aa67ac62811df7112fb6fb08beea61376a86fbb
 arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_aarch64_linux_hotspot_8u372b07.tar.gz
 arm64_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b95
 armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_arm_linux_hotspot_8u372b07.tar.gz
-armhf_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b95
+armhf_checksum = e58e017012838ae4f0db78293e3246cc09958e6ea9a2393c5947ec003bf736dd
 ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_ppc64le_linux_hotspot_8u372b07.tar.gz
 ppc64el_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b95
 


### PR DESCRIPTION
Update Debian checksums for JRE8 / PPC64 LE & ARM32