### PR TITLE
Add Debian Bookworm support to ca-certificates package

### DIFF
--- a/linux/ca-certificates/debian/src/main/packaging/debian/changelog
+++ b/linux/ca-certificates/debian/src/main/packaging/debian/changelog
@@ -1,3 +1,9 @@
+adoptium-ca-certificates (1.0.2-1) STABLE; urgency=medium
+
+  * Add Debian Bookworm to the list of supported releases.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 13 Jun 2023 13:08:30 +0000
+
 adoptium-ca-certificates (1.0.1-1) STABLE; urgency=medium
 
   * Add Ubuntu Kinetic (22.10) to the list of supported Ubuntu releases.

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/AptOperationsTest.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/AptOperationsTest.java
@@ -60,7 +60,7 @@ class AptOperationsTest {
 			assertThat(result.getExitCode()).isEqualTo(0);
 			assertThat(result.getStdout())
 				.contains("Package: adoptium-ca-certificates")
-				.contains("Version: 1.0.1-1")
+				.contains("Version: 1.0.2-1")
 				.contains("Priority: optional")
 				.contains("Architecture: all")
 				.contains("Status: install ok installed");


### PR DESCRIPTION
Fixes https://github.com/adoptium/adoptium-support/issues/816 and is the final step in resolving https://github.com/adoptium/installer/issues/670 (Note: Most of the support was added in https://github.com/adoptium/installer/pull/591 but the ca-certificates package does not get pushed to new directories unless a version change it made, which is what this PR will do.