### PR TITLE
Change Microsoft dependency to ca-certificates

### DIFF
--- a/linux/jdk/debian/src/main/packaging/microsoft/11/debian/control
+++ b/linux/jdk/debian/src/main/packaging/microsoft/11/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 11), lsb-release
 
 Package: msopenjdk-11
 Architecture: amd64 arm64
-Depends: adoptium-ca-certificates,
+Depends: ca-certificates,
          java-common,
          libc6,
          zlib1g

--- a/linux/jdk/debian/src/main/packaging/microsoft/17/debian/control
+++ b/linux/jdk/debian/src/main/packaging/microsoft/17/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 11), lsb-release
 
 Package: msopenjdk-17
 Architecture: amd64 arm64
-Depends: adoptium-ca-certificates,
+Depends: ca-certificates,
          java-common,
          libc6,
          zlib1g


### PR DESCRIPTION
Changes the dependency from `adoptium-ca-certificates` to `ca-certificates`. 