### PR TITLE
switch MS OpenJDK installers to depend on deb CACerts

### DIFF
--- a/linux/jdk/debian/src/main/packaging/microsoft/11/debian/control
+++ b/linux/jdk/debian/src/main/packaging/microsoft/11/debian/control
@@ -9,6 +9,7 @@ Architecture: amd64 arm64
 Depends: ca-certificates,
          java-common,
          libc6,
+         p11-kit,
          zlib1g
 Recommends: libasound2,
             libx11-6,

--- a/linux/jdk/debian/src/main/packaging/microsoft/11/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/microsoft/11/debian/rules
@@ -65,9 +65,12 @@ override_dh_auto_install:
 	# Strip bundled Freetype and use OS package instead.
 	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/libfreetype.so"
 
-	# Replace bundled cacerts and redirect to adoptium-ca-certificates.
-	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"
-	ln -s /etc/ssl/certs/adoptium/cacerts "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"
+	# Update "cacerts" bundle to use Debian's CA certificates and make sure it stays up-to-date with changes to Debian's store.
+	echo '\#!/usr/bin/env bash' > /etc/ca-certificates/update.d/docker-openjdk;
+	echo 'set -Eeuo pipefail' >> /etc/ca-certificates/update.d/docker-openjdk;
+	echo 'trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"' >> /etc/ca-certificates/update.d/docker-openjdk;
+	chmod +x /etc/ca-certificates/update.d/docker-openjdk;
+	/etc/ca-certificates/update.d/docker-openjdk;
 
 	# Ensure src.zip is present in the root folder of the JDK.
 	if [ ! -f "$(d)/$(jvm_home)/$(jvm_dir)/src.zip" ]; then \

--- a/linux/jdk/debian/src/main/packaging/microsoft/17/debian/control
+++ b/linux/jdk/debian/src/main/packaging/microsoft/17/debian/control
@@ -9,6 +9,7 @@ Architecture: amd64 arm64
 Depends: ca-certificates,
          java-common,
          libc6,
+         p11-kit,
          zlib1g
 Recommends: libasound2,
             libx11-6,

--- a/linux/jdk/debian/src/main/packaging/microsoft/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/microsoft/17/debian/rules
@@ -65,9 +65,12 @@ override_dh_auto_install:
 	# Strip bundled Freetype and use OS package instead.
 	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/libfreetype.so"
 
-	# Replace bundled cacerts and redirect to adoptium-ca-certificates.
-	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"
-	ln -s /etc/ssl/certs/adoptium/cacerts "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"
+	# Update "cacerts" bundle to use Debian's CA certificates and make sure it stays up-to-date with changes to Debian's store.
+	echo '\#!/usr/bin/env bash' > /etc/ca-certificates/update.d/docker-openjdk;
+	echo 'set -Eeuo pipefail' >> /etc/ca-certificates/update.d/docker-openjdk;
+	echo 'trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"' >> /etc/ca-certificates/update.d/docker-openjdk;
+	chmod +x /etc/ca-certificates/update.d/docker-openjdk;
+	/etc/ca-certificates/update.d/docker-openjdk;
 
 	# Ensure src.zip is present in the root folder of the JDK.
 	if [ ! -f "$(d)/$(jvm_home)/$(jvm_dir)/src.zip" ]; then \


### PR DESCRIPTION
fixes: https://github.com/microsoft/openjdk-docker/issues/74