### PR TITLE
Installer updates for JDK11 for July 2023 release

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.19_p7
+pkgver=11.0.20_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-45f56d75da2f55b29e7307cc790958e379abbe6b5f160a3824dc26e320c718e5  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+0b7e894af823484f270031ed6626f78504a7a44f8173d67433e14321d015e669  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jdk (11.0.20.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.20.0.0+8 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 25 Jul 2023 11:59:00 +0000
+
 temurin-11-jdk (11.0.19.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.19.0.0+7 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jdk
 priority = 1111
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200 jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.19_7.tar.gz
-amd64_checksum = 5f19fb28aea3e28fcc402b73ce72f62b602992d48769502effe81c52ca39a581
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.19_7.tar.gz
-arm64_checksum = 0c7763a19b4af4ef5fbae831781b5184e988d6f131d264482399eeaf51b6e254
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jdk_arm_linux_hotspot_11.0.19_7.tar.gz
-armhf_checksum = be07af349f0d2e1ffb7e01e1e8bac8bffd76e22f6cc1354e5b627222e3395f41
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.19_7.tar.gz
-ppc64el_checksum = 1e3704c8e155f8f894953c2a6708a52e6f449bbf5a85450be6fbb2ec76581700
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.19_7.tar.gz
-s390x_checksum = a21e2c30e48df0b7238691833316c008167cbedd4e2f1e677bcb81638420d273
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz
+amd64_checksum = 7a99258af2e3ee9047e90f1c0c1775fd6285085759501295358d934d662e01f9
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20_8.tar.gz
+arm64_checksum = eb821c049c2d2f7c3fbf8ddcce2d608d3aa7d488700e76bfbbebabba93021748
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.20_8.tar.gz
+armhf_checksum = fdf98d94ac3fd49a73a534fd88cf60e757e885c04791d15f76ccfcecb43a25e0
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.20_8.tar.gz
+ppc64el_checksum = 1125931b3a38e6e305a1932fc6cfd0b023a0fbec2cab10e835a2ee2c50848b42
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.20_8.tar.gz
+s390x_checksum = 688c83d9edf2204220df94ce5bab4a6d19f3d91bc0e500f31dda41e16d9a383f
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 11.0.19+7
+%global upstream_version 11.0.20+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.19.0.0.7
-%global spec_release 2
+%global spec_version 11.0.20.0.0.8
+%global spec_release 1
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -264,6 +264,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8.adopt0
+- Eclipse Temurin 11.0.20+8 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-1.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 11.0.19+7
+%global upstream_version 11.0.20+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.19.0.0.7
-%global spec_release 2
+%global spec_version 11.0.20.0.0.8
+%global spec_release 1
 %global priority 1111
 
 %global source_url_base https://github.com/adoptium/temurin11-binaries/releases/download
@@ -255,6 +255,8 @@ fi
 %{prefix}
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8.adopt0
+- Eclipse Temurin 11.0.20+8 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-1.adopt0

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.19_p7
+pkgver=11.0.20_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -72,5 +72,5 @@ _jre() {
 }
 
 sha256sums="
-b5d71cdf3032040e7d2a577712bf525e32e87686af3430219308a39878b98851  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+ad1645501461a986f6f40ede6a76198f267c694c06150a9ed36ae95e7d012287  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jre (11.0.20.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.20.0.0+8 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 25 Jul 2023 11:59:00 +0000
+
 temurin-11-jre (11.0.19.0.0+7-1) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.19.0.0+7-1 release.

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jre
 priority = 1112
 jvm_tools = jaotc java jfr jjs jrunscript keytool pack200 rmid rmiregistry unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19+7/OpenJDK11U-jre_x64_linux_hotspot_11.0.19_7.tar.gz
-amd64_checksum = 32dcf760664f93531594b72ce9226e9216567de5705a23c9ff5a77c797948054
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19+7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.19_7.tar.gz
-arm64_checksum = 78a07bd60c278f65bafd0df93890d909ff60259ccbd22ad71a1c3b312906508e
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19+7/OpenJDK11U-jre_arm_linux_hotspot_11.0.19_7.tar.gz
-armhf_checksum = cb754b055177381f9f6852b7e5469904a15edddd7f8e136043c28b1e33aee47c
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19+7/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.19_7.tar.gz
-ppc64el_checksum = 8019d938e5525938ec8e68e2989c4413263b0d9b7b3f20fe0c45f6d967919cfb
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19+7/OpenJDK11U-jre_s390x_linux_hotspot_11.0.19_7.tar.gz
-s390x_checksum = 058419435fe6212d1bc305a14f578c314f9ff9a2d96d523c178120e84231c733
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_x64_linux_hotspot_11.0.20_8.tar.gz
+amd64_checksum = ffb070c26ea22771f78769c569c9db3412e6486434dc6df1fd3c3438285766e7
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.20_8.tar.gz
+arm64_checksum = 45e190920fb3ec61ee5213a7bd98553abf2ae7692eb9daa504fcdc9d59a7cfc4
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_arm_linux_hotspot_11.0.20_8.tar.gz
+armhf_checksum = 1e2a02364084b2d054e88a871f3efaa4450ae4f087b8f806fd95c15d5affcc7b
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.20_8.tar.gz
+ppc64el_checksum = 61034834b61bf080392218b25dcac2d9e3505b5e4f53539704d496be4181aadf
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_s390x_linux_hotspot_11.0.20_8.tar.gz
+s390x_checksum = 0c7050976914e0613179446de62bb20d2845ae809f6d31bc0ed8d136f8fd3d9b
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.19+7
+%global upstream_version 11.0.20+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.19.0.0.7
+%global spec_version 11.0.20.0.0.8
 %global spec_release 1
 %global priority 1112
 
@@ -199,6 +199,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8.adopt0
+- Eclipse Temurin 11.0.20+8 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7.adopt0
 - Eclipse Temurin 11.0.19+7 release.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10-3.adopt0

--- a/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.19+7
+%global upstream_version 11.0.20+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.19.0.0.7
+%global spec_version 11.0.20.0.0.8
 %global spec_release 1
 %global priority 1112
 
@@ -190,6 +190,8 @@ fi
 %{prefix}
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8.adopt0
+- Eclipse Temurin 11.0.20+8 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7.adopt0
 - Eclipse Temurin JRE 11.0.19+7 release.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9-2.adopt0


### PR DESCRIPTION
Based on the [April 2023 JDK11 updates](https://github.com/adoptium/installer/pull/661).

@steelhead31 - Could you take a look at this before formal reviews are solicited, please?