### PR TITLE
Installer updates for JDK8 for July 2023 release

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jdk
-pkgver=8.372.07
+pkgver=8.382.05
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -68,6 +68,6 @@ package() {
 }
 
 sha256sums="
-cfdf8e07c8eeb087b7a2895b90fc0a19986bcff85006f1e2b708e3964909aa8e  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+6cf2d4925c387c4cdc0bf2e71de3690527141b5244695d0b3109ce83a8512235  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 "

--- a/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -16,7 +16,6 @@ makedepends="
 	libpng-dev
 	libxcomposite-dev
 	libxinerama-dev
-	libxp-dev
 	libxrender-dev
 	libxslt
 	libxt-dev

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jdk (8.0.382.0.0+5) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.382.0.0+5 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
+ 
 temurin-8-jdk (8.0.372.0.0+7-1) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.372.0.0+7-1 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jdk
 priority = 1081
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = appletviewer clhsdb extcheck hsdb idlj jar jarsigner java javac javadoc javah javap jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc jexec
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jdk_x64_linux_hotspot_8u372b07.tar.gz
-amd64_checksum = 78a0b3547d6f3d46227f2ad8c774248425f20f1cd63f399b713f0cdde2cc376c
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jdk_aarch64_linux_hotspot_8u372b07.tar.gz
-arm64_checksum = 195808eb42ab73535c84de05188914a52a47c1ac784e4bf66de95fe1fd315a5a
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jdk_arm_linux_hotspot_8u372b07.tar.gz
-armhf_checksum = 3f4848700a4bf856d3c138dc9c2b305b978879c8fbef5aa7df34a7c2fe1b64b8
-ppc64el_tarball_url = 	https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u372b07.tar.gz
-ppc64el_checksum = bb85303848fe402d4f1004f748f80ccb39cb11f356f50a513555d1083c3913b8
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz
+amd64_checksum = 789ad24dc0d9618294e3ba564c9bfda9d3f3a218604350e0ce0381bbc8f28db3
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_aarch64_linux_hotspot_8u382b05.tar.gz
+arm64_checksum = 0951398197b7bef39ab987b59c22852812ee2c2da6549953eed7fced4c08e13d
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_arm_linux_hotspot_8u382b05.tar.gz
+armhf_checksum = 5d805ff157f272acf0f7d192f21af4a3b68c840333ca95568e4e07142efc369d
+ppc64el_tarball_url = 	https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u382b05.tar.gz
+ppc64el_checksum = 509c923c308d1f4f28fd0068831a59250a05b8ca173ca92fb2be2e2e1f9ff3f9
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 8u372-b07
+%global upstream_version 8u382-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.372.0.0.7
-%global spec_release 2
+%global spec_version 8.0.382.0.0.5
+%global spec_release 1
 %global priority 1081
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -278,6 +278,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.382.0.0.5.adopt0
+- Eclipse Temurin 8.0.382-b05 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 8u372-b07
+%global upstream_version 8u382-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.372.0.0.7
-%global spec_release 2
+%global spec_version 8.0.382.0.0.5
+%global spec_release 1
 %global priority 1081
 
 %global source_url_base https://github.com/adoptium/temurin8-binaries/releases/download
@@ -268,6 +268,8 @@ fi
 %{prefix}
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.382.0.0.5.adopt0
+- Eclipse Temurin 8.0.382-b05 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0

--- a/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jre
-pkgver=8.372.07
+pkgver=8.382.05
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -61,5 +61,5 @@ ls ${srcdir}
 }
 
 sha256sums="
-95d8cb8b5375ec00a064ed728eb60d925d44c1a79fe92f6ca7385b5863d4f78c  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+7040d865493f13204194c5a1add63e22516b1fa4481264baa6a5b2614a275a0e  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -16,7 +16,6 @@ makedepends="
 	libpng-dev
 	libxcomposite-dev
 	libxinerama-dev
-	libxp-dev
 	libxrender-dev
 	libxslt
 	libxt-dev

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jre (8.0.382.0.0+5) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.382.0.0+5 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
+
 temurin-8-jre (8.0.372.0.0.7-1) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.372.0.0.7-1 release.

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jre
 priority = 1082
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = java jjs keytool orbd pack200 policytool rmid rmiregistry servertool tnameserv unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_x64_linux_hotspot_8u372b07.tar.gz
-amd64_checksum = b6fdfe32085a884c11b31f66aa67ac62811df7112fb6fb08beea61376a86fbb4
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_aarch64_linux_hotspot_8u372b07.tar.gz
-arm64_checksum = f8e440273c8feb3fcfaca88ba18fec291deae18a548adde8a37cd1db08107b95
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_arm_linux_hotspot_8u372b07.tar.gz
-armhf_checksum = e58e017012838ae4f0db78293e3246cc09958e6ea9a2393c5947ec003bf736dd
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u372-b07/OpenJDK8U-jre_ppc64le_linux_hotspot_8u372b07.tar.gz
-ppc64el_checksum = ba5f8141a16722e39576bf42b69d2b8ebf95fc2c05441e3200f609af4dd9f1ea
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_x64_linux_hotspot_8u382b05.tar.gz
+amd64_checksum = 1fad165cc243e8db1b9cf226134acdfe3dc5919cd98c5fd9210de3cf9edeabd7
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_aarch64_linux_hotspot_8u382b05.tar.gz
+arm64_checksum = 8cf329aa76d5b6abe35dd94e5087d9d14993fa13b43bbaed3b26bda4c57162c4
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_arm_linux_hotspot_8u382b05.tar.gz
+armhf_checksum = b92fb3972372b5d1f9fb51815def903105722b747f680b7ecf2ba2ba863ab156
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_ppc64le_linux_hotspot_8u382b05.tar.gz
+ppc64el_checksum = 8f0706f16373078e46666a6035325792584cd565b4cc5a793a37312599f3af0b
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u372-b07
+%global upstream_version 8u382-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.372.0.0.7
+%global spec_version 8.0.382.0.0.5
 %global spec_release 1
 %global priority 1082
 
@@ -192,6 +192,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.382.0.0.5.adopt0
+- Eclipse Temurin 8.0.382-b05 release.
 * Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
 - Eclipse Temurin 8.0.372-b07 release 1.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9-3.adopt0

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u372-b07
+%global upstream_version 8u382-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.372.0.0.7
+%global spec_version 8.0.382.0.0.5
 %global spec_release 1
 %global priority 1082
 
@@ -183,6 +183,8 @@ fi
 
 %changelog
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.382.0.0.5.adopt0
+- Eclipse Temurin 8.0.382-b05 release.
 * Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
 - Eclipse Temurin 8.0.372-b07 release 1.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9-2.adopt0


### PR DESCRIPTION
Styled after the changes in [April](https://github.com/adoptium/installer/pull/518/files).