### PR TITLE
Installer updates for JDK17 for July 2023 release

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.7_p7
+pkgver=17.0.8_p7
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-b6edac2fa669876ef16b4895b36b61d01066626e7a69feba2acc19760c8d18cb  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+90eb413eeed9cc2813f7d66d348c35475148c0cdc41c8f9ef2f26d51078e287e  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jdk (17.0.8.0.0+7) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.8.0.0+7 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
+
 temurin-17-jdk (17.0.7.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.7.0.0+7 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jdk
 priority = 1711
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.7_7.tar.gz
-amd64_checksum = e9458b38e97358850902c2936a1bb5f35f6cffc59da9fcd28c63eab8dbbfbc3b
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.7_7.tar.gz
-arm64_checksum = 0084272404b89442871e0a1f112779844090532978ad4d4191b8d03fc6adfade
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.7_7.tar.gz
-armhf_checksum = e7a84c3e59704588510d7e6cce1f732f397b54a3b558c521912a18a1b4d0abdc
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.7_7.tar.gz
-ppc64el_checksum = 8f4366ff1eddb548b1744cd82a1a56ceee60abebbcbad446bfb3ead7ac0f0f85
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.7_7.tar.gz
-s390x_checksum = 2d75540ae922d0c4162729267a8c741e2414881a468fd2ce4140b4069ba47ca9
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8_7.tar.gz
+amd64_checksum = aa5fc7d388fe544e5d85902e68399d5299e931f9b280d358a3cbee218d6017b0
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8_7.tar.gz
+arm64_checksum = c43688163cfdcb1a6e6fe202cc06a51891df746b954c55dbd01430e7d7326d00
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8_7.tar.gz
+armhf_checksum = 33d972efd78b70a07aed793a6ebcb52a5129707e8c62268e478d1c2df15898e1
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8_7.tar.gz
+ppc64el_checksum = 88f5d14cc84a4bcfe50aa275092ae97a0edf7205269ed12c1972bf613bc52b1e
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8_7.tar.gz
+s390x_checksum = 055d8bd0eebf137cf3506fb84817ce2d858597f21067d9a1268f08916738b435
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 17.0.7+7
+%global upstream_version 17.0.8+7
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.7.0.0.7
-%global spec_release 2
+%global spec_version 17.0.8.0.0.7
+%global spec_release 1
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin17-binaries/releases/download
@@ -261,6 +261,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7.adopt0
+- Eclipse Temurin 17.0.8+7 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-1.adopt0

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.7+7
+%global upstream_version 17.0.8+7
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
-%global spec_version 17.0.7.0.0.7
-%global spec_release 2
+%global spec_version 17.0.8.0.0.7
+%global spec_release 1
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global priority 1161
 
@@ -251,6 +251,8 @@ fi
 %{prefix}
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7.adopt0
+- Eclipse Temurin 17.0.8+7 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-2.adopt0
 - Fix alternatives linking.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-1.adopt0

--- a/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.7_p7
+pkgver=17.0.8_p7
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -71,5 +71,5 @@ _jre() {
 }
 
 sha256sums="
-711f837bacf8222dee9e8cd7f39941a4a0acf869243f03e6038ca3ba189f66ca  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+4cdf34da04fe3ed705c6ca0281049baa9f772e6321a77fe395023fb8e41fdb9f  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jre (17.0.8.0.0+7) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.8.0.0+7 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
+ 
 temurin-17-jre (17.0.7+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.7.0.0+7 release.

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jre
 priority = 1712
 jvm_tools = java jfr jrunscript keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_x64_linux_hotspot_17.0.7_7.tar.gz
-amd64_checksum = bb025133b96266f6415d5084bb9b260340a813968007f1d2d14690f20bd021ca
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.7_7.tar.gz
-arm64_checksum = 2ff6a4fd1fa354047c93ba8c3179967156162f27bd683aee1f6e52a480bcbe6a
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_arm_linux_hotspot_17.0.7_7.tar.gz
-armhf_checksum = 5b0401199c7c9163b8395ebf25195ed395fec7b7ef7158c36302420cf993825a
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.7_7.tar.gz
-ppc64el_checksum = cc25e74c0817cd4d943bba056b256b86e0e9148bf41d7600c5ec2e1eadb2e470
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7+7/OpenJDK17U-jre_s390x_linux_hotspot_17.0.7_7.tar.gz
-s390x_checksum = 393f6348c6c0cb12699565cf23a7617fbfce973e6d47584a0920e99fbb1b1e3e
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_x64_linux_hotspot_17.0.8_7.tar.gz
+amd64_checksum = dddbb5f817a77445711528a414678806b00b83c92701fe595c50cdb207758ae9
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.8_7.tar.gz
+arm64_checksum = 42525ae2951a669803c75ba5987dc8333c664dae50c3e12174f736a506b4aa15
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_arm_linux_hotspot_17.0.8_7.tar.gz
+armhf_checksum = 20fa06a86e1647f5997c511dd19e4d1c9839d2500f835973fc9b3c86b87030a0
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.8_7.tar.gz
+ppc64el_checksum = 1cf2cf7dca98c74860799b162b9f2eeaaf1ad1e78f5cb7479fe7bd1ccfea3227
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_s390x_linux_hotspot_17.0.8_7.tar.gz
+s390x_checksum = 4df17b19510864651c1d620baaf13766a448d43ee7848ea9ff69db10d26467b6
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.7+7
+%global upstream_version 17.0.8+7
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.7.0.0.7
+%global spec_version 17.0.8.0.0.7
 %global spec_release 1
 %global priority 1712
 
@@ -186,6 +186,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7.adopt0
+- Eclipse Temurin 17.0.8+7 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7.adopt0
 - Eclipse Temurin JRE 17.0.7+7 release.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10-3.adopt0

--- a/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.7+7
+%global upstream_version 17.0.8+7
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.7.0.0.7
+%global spec_version 17.0.8.0.0.7
 %global spec_release 1
 %global priority 1712
 
@@ -176,6 +176,8 @@ fi
 %{prefix}
 
 %changelog
+* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7.adopt0
+- Eclipse Temurin 17.0.8+7 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7.adopt0
 - Eclipse Temurin JRE 17.0.7+7 release.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10-2.adopt0


### PR DESCRIPTION
Styled after the [April PR](https://github.com/adoptium/installer/pull/660/files)