### PR TITLE
Typo fix

### DIFF
--- a/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
@@ -37,7 +37,7 @@ public class SuseFlavours implements ArgumentsProvider {
 		return Stream.of(
 			Arguments.of("opensuse/leap", "15.3"),
 			Arguments.of("opensuse/leap", "15.4"),
-			Arguments.of("registry.suse.com/suse/sles12sp5", "latest")
+			Arguments.of("registry.suse.com/suse/sles12sp5", "latest"),
 			Arguments.of("registry.suse.com/suse/sle15", "latest")
 		);
 	}

--- a/linux/jre/suse/src/packageTest/java/packaging/SuseFlavours.java
+++ b/linux/jre/suse/src/packageTest/java/packaging/SuseFlavours.java
@@ -37,7 +37,7 @@ public class SuseFlavours implements ArgumentsProvider {
 		return Stream.of(
 			Arguments.of("opensuse/leap", "15.3"),
 			Arguments.of("opensuse/leap", "15.4"),
-			Arguments.of("registry.suse.com/suse/sles12sp5", "latest")
+			Arguments.of("registry.suse.com/suse/sles12sp5", "latest"),
 			Arguments.of("registry.suse.com/suse/sle15", "latest")
 		);
 	}


### PR DESCRIPTION
A missing comma causes associated Git checks to fail with a compile error. Fixing the comma.