### PR TITLE
Fix errant Date in RPM spec for JDK8

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -274,7 +274,7 @@ fi
 - Eclipse Temurin 11.0.18+10 release 3.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin 11.0.18+10 release.
-* Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0
+* Thu Oct 27 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0
 - Eclipse Temurin 11.0.17+8 release.
 * Tue Aug 23 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.16.1.0.1.adopt0
 - Eclipse Temurin 11.0.16.1+1 release.

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -271,7 +271,7 @@ fi
 - Eclipse Temurin 17.0.6+10 release 3.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin 17.0.6+10 release.
-* Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0
+* Thu Oct 27 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0
 - Eclipse Temurin 17.0.5+8 release.
 * Tue Aug 23 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.4.1.0.1.adopt0
 - Eclipse Temurin 17.0.4.1+8 release.

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -282,7 +282,7 @@ fi
 - Eclipse Temurin 8.0.382-b05 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-2.adopt0
 - Fix alternatives linking.
-* Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
+* Mon Apr 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
 - Eclipse Temurin 8.0.372-b07 release 1.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9-2.adopt0
 - Eclipse Temurin 8.0.362-b09 release 2.

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u372-b07-aarch32-20230426
+%global upstream_version 8u382-b05-aarch32-20230719
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -290,7 +290,7 @@ fi
 - Eclipse Temurin 8.0.362-b09 release.
 * Thu Nov 03 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.352.0.0.8.adopt0
 - Eclipse Temurin 8.0.352-b08 release.
-* Thu Aug 08 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.345.0.0.1.adopt0
+* Thu Aug 18 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.345.0.0.1.adopt0
 - Eclipse Temurin 8.0.345-b01 release.
 * Thu May 05 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.332.0.0.9.adopt0
 - Eclipse Temurin 8.0.332-b09 release.

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -265,7 +265,7 @@ fi
 - Eclipse Temurin 11.0.18+10 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.18.0.0.10.adopt0
 - Eclipse Temurin 11.0.18+10 release.
-* Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0
+* Thu Oct 27 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.17.0.0.8.adopt0
 - Eclipse Temurin 11.0.17+8 release.
 * Tue Aug 23 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.16.1.0.1.adopt0
 - Eclipse Temurin 11.0.16.1+1 release.

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -184,7 +184,7 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/keytool keytool %{prefix}/bin/keytool \
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry \
                         --slave %{_bindir}/jexec jexec %{prefix}/lib/jexec \
-                        --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \ 
+                        --slave %{_bindir}/jspawnhelper jspawnhelper %{prefix}/lib/jspawnhelper \
                         --slave  %{_mandir}/man1/java.1 java.1 %{prefix}/man/man1/java.1 \
                         --slave  %{_mandir}/man1/keytool.1 keytool.1 %{prefix}/man/man1/keytool.1 \
                         --slave  %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{prefix}/man/man1/rmiregistry.1 \
@@ -261,7 +261,7 @@ fi
 - Eclipse Temurin 17.0.6+10 release 2.
 * Wed Jan 18 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10.adopt0
 - Eclipse Temurin 17.0.6+10 release.
-* Thu Oct 25 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0
+* Thu Oct 27 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.5.0.0.8.adopt0
 - Eclipse Temurin 17.0.5+8 release.
 * Tue Aug 23 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.4.1.0.1.adopt0
 - Eclipse Temurin 17.0.4.1+8 release.

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u372-b07-aarch32-20230426
+%global upstream_version 8u382-b05-aarch32-20230719
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -272,7 +272,7 @@ fi
 - Eclipse Temurin 8.0.382-b05 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-2.adopt0
 - Fix alternatives linking.
-* Mon Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
+* Mon Apr 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.372.0.0.7-1.adopt0
 - Eclipse Temurin 8.0.372-b07 release 1.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.362.0.0.9-2.adopt0
 - Eclipse Temurin 8.0.362-b09 release 2.


### PR DESCRIPTION
Fixes #705 

Installer tests fail as Thursday August 08th is not a valid date.. appears it should be * Thu Aug 18 2022 , there is a similar issue in the Suse spec file for an April date. The recent bump to container versions for checking RPMs, now appears to validate dates.

* Thu Aug 08 2022 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.345.0.0.1.adopt0
