### PR TITLE
Fix Mapping Of arm32 parameter in jenkins to value required

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -385,7 +385,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7hl': 'armv7hl',
+        'armv7l': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'


### PR DESCRIPTION
Fix the mapping Of arm32 parameter in jenkins (armv7l) to value required in artifactory (armv7hf)