### PR TITLE
Fix Handling of Arm32 for RHEL & Suse

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -193,7 +193,7 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') &&  ("${ARCH}" == 'armv7l')) {
+    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') && "${ARCH}" == 'armv7l') {
       ARCH = 'armv7hl'
     }
     setup("${DISTRO}", "${ARCH}")
@@ -388,7 +388,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7l': 'armv7hl',
+        'armv7hl': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -163,14 +163,6 @@ def jenkinsStepDeb() {
     if ("${ARCH}" == 'all') {
         debArchAllList = ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x']
     }
-    // remove s390x for JDK8 and JDK20
-    if ("${VERSION}" == '8' || "${VERSION}" == '20') {
-        debArchAllList.remove('s390x')
-    }
-    // remove armv7l for JDK20
-    if ("${VERSION}" == '20') {
-        debArchAllList.remove('armv7l')
-    }
     debArchAllList.each { DebARCH ->
         // special handle: no label x86_64 only x64 for debian agent
         def debLabel = "${DebARCH}&&docker"
@@ -193,9 +185,6 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') && "${ARCH}" == 'armv7l') {
-      ARCH = 'armv7hl'
-    }
     setup("${DISTRO}", "${ARCH}")
     unstash 'installercode'
     buildAndTest("${DISTRO}", "${ARCH}")
@@ -225,23 +214,23 @@ def buildAndTest(String DISTRO, String buildArch) {
             if (params.enableGpgSigning) {
                 // Use Adoptium GPG key for signing
                 withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
-                    buildCli(DISTRO, buildArch, GPG_KEY)
+                    buildCLi(DISTRO, buildArch, GPG_KEY)
                 }
             } else {
-                buildCli(DISTRO, buildArch)
+                buildCLi(DISTRO, buildArch)
             }
         } else {
             def gBuildTask = (buildArch == 'x86_64') ? "package${TYPE}${DISTRO} check${TYPE}${DISTRO}" : "package${TYPE}${DISTRO}"
             def debArchList = [
                 'x86_64' : 'amd64',
-                'armv7l': 'armv7hl',
+                'armv7l': 'armhf',
                 'aarch64': 'arm64',
                 'ppc64le': 'ppc64el',
                 's390x'  : 's390x'
             ]
-            def buildCli = "./gradlew ${gBuildTask} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${debArchList[buildArch]}"
-            buildCli = params.enableDebug.toBoolean() ? buildCli + ' --stacktrace' : buildCli
-            sh("$buildCli")
+            def buildCLI = "./gradlew ${gBuildTask} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${debArchList[buildArch]}"
+            buildCLI = params.enableDebug.toBoolean() ? buildCLI + ' --stacktrace' : buildCLI
+            sh("$buildCLI")
         }
     } catch (Exception ex) {
         echo 'Exception in buildAndTest: ' + ex
@@ -252,15 +241,13 @@ def buildAndTest(String DISTRO, String buildArch) {
     }
 }
 
-private void buildCli(String DISTRO, String buildArch, String GPG_KEY = null) {
-    def buildCli = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
+private void buildCLi(String DISTRO, String buildArch, String GPG_KEY = null) {
+    def buildCLI = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
     if (GPG_KEY) {
         buildCli += " -PGPG_KEY=${GPG_KEY}"
     }
-    if (params.enableDebug.toBoolean()) {
-        buildCli += " --stacktrace"
-    }
-    sh(buildCli)
+    buildCLI = params.enableDebug.toBoolean() ? buildCLI + ' --stacktrace' : buildCLI
+    sh("$buildCLI")
 }
 
 def uploadArtifacts(String DISTRO, String buildArch) {
@@ -285,11 +272,7 @@ def uploadAlpineArtifacts(String buildArch) {
         spec: """{
             "files": [
                 {
-                "pattern": "**/build/ospackage/temurin-*j*.apk",
-                "target": "apk/alpine/main/${buildArch}/"
-                },
-                {
-                "pattern": "**/build/ospackage/temurin-*src*.apk",
+                "pattern": "**/build/ospackage/temurin-*.apk",
                 "target": "apk/alpine/main/${buildArch}/"
                 }
             ]
@@ -298,6 +281,7 @@ def uploadAlpineArtifacts(String buildArch) {
 }
 
 def uploadDebArtifacts(String buildArch) {
+    // full list of all platforms, up to user to opt out s390x+jdk8/jre8
     def debArchList = [
         'x86_64' : 'amd64',
         'armv7l': 'armhf',
@@ -305,15 +289,6 @@ def uploadDebArtifacts(String buildArch) {
         'ppc64le': 'ppc64el',
         's390x'  : 's390x'
     ]
-    // if VERSION is 8 or 20 remove s390x from the list
-    if (VERSION == '8' || VERSION == '20') {
-        debArchList.remove('s390x')
-    }
-    // if VERSION is 20 remove armv7l from the list
-    if (VERSION == '20') {
-        debArchList.remove('armv7l')
-    }
-
     /*
         Debian/Ubuntu   10.0       11.0        16.04     20.04    22.04    22.10
         add more into list when available for release
@@ -363,45 +338,37 @@ def uploadDebArtifacts(String buildArch) {
 
 def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def distro_Package = [
-        'RedHat' : [
-            'rpm/centos/7',
-            'rpm/rocky/8',
-            'rpm/rhel/7',
-            'rpm/rhel/8',
-            'rpm/rhel/9',
-            'rpm/fedora/35',
-            'rpm/fedora/36',
-            'rpm/fedora/37',
-            'rpm/fedora/38',
-            'rpm/oraclelinux/7',
-            'rpm/oraclelinux/8',
-            'rpm/amazonlinux/2'
+    'redhat' : [
+        'rpm/centos/7',
+        'rpm/rocky/8',
+        'rpm/rhel/7',
+        'rpm/rhel/8',
+        'rpm/rhel/9',
+        'rpm/fedora/35',
+        'rpm/fedora/36',
+        'rpm/fedora/37',
+        'rpm/fedora/38',
+        'rpm/oraclelinux/7',
+        'rpm/oraclelinux/8',
+        'rpm/amazonlinux/2'
 
-        ],
-        'Suse'   : [
-            'rpm/opensuse/15.3',
-            'rpm/opensuse/15.4',
-            'rpm/sles/12',
-            'rpm/sles/15'
+    ],
+    'suse'   : [
+        'rpm/opensuse/15.3',
+        'rpm/opensuse/15.4',
+        'rpm/sles/12',
+        'rpm/sles/15'
         ]
     ]
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
+    // full list of all platforms, up to user to opt out s390x+jdk8 from input
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7l': 'armv7hl',
+        'armv7hl': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'
     ]
-    // if VERSION is 8 or 20 remove s390x from the list
-    if (VERSION == '8' || VERSION == '20') {
-        rpmArchList.remove('s390x')
-    }
-    // if VERSION is 20 remove armv7hl from the list
-    if (VERSION == '20') {
-        rpmArchList.remove('armv7hl')
-    }
-
     if ("${rpmArch}" != 'all') {
         // when only build and upload one arch, reset
         rpmArchList = [("${rpmArch}" as String): "${rpmArchList[rpmArch]}"]

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -193,6 +193,9 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+    if ("${ARCH}" == 'armv7l') {
+        ARCH = 'armv7hl'
+    }
     setup("${DISTRO}", "${ARCH}")
     unstash 'installercode'
     buildAndTest("${DISTRO}", "${ARCH}")

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -163,6 +163,14 @@ def jenkinsStepDeb() {
     if ("${ARCH}" == 'all') {
         debArchAllList = ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x']
     }
+    // remove s390x for JDK8 and JDK20
+    if ("${VERSION}" == '8' || "${VERSION}" == '20') {
+        debArchAllList.remove('s390x')
+    }
+    // remove armv7l for JDK20
+    if ("${VERSION}" == '20') {
+        debArchAllList.remove('armv7l')
+    }
     debArchAllList.each { DebARCH ->
         // special handle: no label x86_64 only x64 for debian agent
         def debLabel = "${DebARCH}&&docker"
@@ -185,6 +193,9 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
+    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') && "${ARCH}" == 'armv7l') {
+      ARCH = 'armv7hl'
+    }
     setup("${DISTRO}", "${ARCH}")
     unstash 'installercode'
     buildAndTest("${DISTRO}", "${ARCH}")
@@ -214,23 +225,23 @@ def buildAndTest(String DISTRO, String buildArch) {
             if (params.enableGpgSigning) {
                 // Use Adoptium GPG key for signing
                 withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
-                    buildCLi(DISTRO, buildArch, GPG_KEY)
+                    buildCli(DISTRO, buildArch, GPG_KEY)
                 }
             } else {
-                buildCLi(DISTRO, buildArch)
+                buildCli(DISTRO, buildArch)
             }
         } else {
             def gBuildTask = (buildArch == 'x86_64') ? "package${TYPE}${DISTRO} check${TYPE}${DISTRO}" : "package${TYPE}${DISTRO}"
             def debArchList = [
                 'x86_64' : 'amd64',
-                'armv7l': 'armhf',
+                'armv7l': 'armv7hl',
                 'aarch64': 'arm64',
                 'ppc64le': 'ppc64el',
                 's390x'  : 's390x'
             ]
-            def buildCLI = "./gradlew ${gBuildTask} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${debArchList[buildArch]}"
-            buildCLI = params.enableDebug.toBoolean() ? buildCLI + ' --stacktrace' : buildCLI
-            sh("$buildCLI")
+            def buildCli = "./gradlew ${gBuildTask} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${debArchList[buildArch]}"
+            buildCli = params.enableDebug.toBoolean() ? buildCli + ' --stacktrace' : buildCli
+            sh("$buildCli")
         }
     } catch (Exception ex) {
         echo 'Exception in buildAndTest: ' + ex
@@ -241,13 +252,15 @@ def buildAndTest(String DISTRO, String buildArch) {
     }
 }
 
-private void buildCLi(String DISTRO, String buildArch, String GPG_KEY = null) {
-    def buildCLI = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
+private void buildCli(String DISTRO, String buildArch, String GPG_KEY = null) {
+    def buildCli = "./gradlew package${TYPE}${DISTRO} check${TYPE}${DISTRO} --parallel -PPRODUCT=${env.PRODUCT} -PPRODUCT_VERSION=${VERSION} -PARCH=${buildArch}"
     if (GPG_KEY) {
         buildCli += " -PGPG_KEY=${GPG_KEY}"
     }
-    buildCLI = params.enableDebug.toBoolean() ? buildCLI + ' --stacktrace' : buildCLI
-    sh("$buildCLI")
+    if (params.enableDebug.toBoolean()) {
+        buildCli += " --stacktrace"
+    }
+    sh(buildCli)
 }
 
 def uploadArtifacts(String DISTRO, String buildArch) {
@@ -272,7 +285,11 @@ def uploadAlpineArtifacts(String buildArch) {
         spec: """{
             "files": [
                 {
-                "pattern": "**/build/ospackage/temurin-*.apk",
+                "pattern": "**/build/ospackage/temurin-*j*.apk",
+                "target": "apk/alpine/main/${buildArch}/"
+                },
+                {
+                "pattern": "**/build/ospackage/temurin-*src*.apk",
                 "target": "apk/alpine/main/${buildArch}/"
                 }
             ]
@@ -281,7 +298,6 @@ def uploadAlpineArtifacts(String buildArch) {
 }
 
 def uploadDebArtifacts(String buildArch) {
-    // full list of all platforms, up to user to opt out s390x+jdk8/jre8
     def debArchList = [
         'x86_64' : 'amd64',
         'armv7l': 'armhf',
@@ -289,6 +305,15 @@ def uploadDebArtifacts(String buildArch) {
         'ppc64le': 'ppc64el',
         's390x'  : 's390x'
     ]
+    // if VERSION is 8 or 20 remove s390x from the list
+    if (VERSION == '8' || VERSION == '20') {
+        debArchList.remove('s390x')
+    }
+    // if VERSION is 20 remove armv7l from the list
+    if (VERSION == '20') {
+        debArchList.remove('armv7l')
+    }
+
     /*
         Debian/Ubuntu   10.0       11.0        16.04     20.04    22.04    22.10
         add more into list when available for release
@@ -338,37 +363,45 @@ def uploadDebArtifacts(String buildArch) {
 
 def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def distro_Package = [
-    'redhat' : [
-        'rpm/centos/7',
-        'rpm/rocky/8',
-        'rpm/rhel/7',
-        'rpm/rhel/8',
-        'rpm/rhel/9',
-        'rpm/fedora/35',
-        'rpm/fedora/36',
-        'rpm/fedora/37',
-        'rpm/fedora/38',
-        'rpm/oraclelinux/7',
-        'rpm/oraclelinux/8',
-        'rpm/amazonlinux/2'
+        'redhat' : [
+            'rpm/centos/7',
+            'rpm/rocky/8',
+            'rpm/rhel/7',
+            'rpm/rhel/8',
+            'rpm/rhel/9',
+            'rpm/fedora/35',
+            'rpm/fedora/36',
+            'rpm/fedora/37',
+            'rpm/fedora/38',
+            'rpm/oraclelinux/7',
+            'rpm/oraclelinux/8',
+            'rpm/amazonlinux/2'
 
-    ],
-    'suse'   : [
-        'rpm/opensuse/15.3',
-        'rpm/opensuse/15.4',
-        'rpm/sles/12',
-        'rpm/sles/15'
+        ],
+        'suse'   : [
+            'rpm/opensuse/15.3',
+            'rpm/opensuse/15.4',
+            'rpm/sles/12',
+            'rpm/sles/15'
         ]
     ]
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
-    // full list of all platforms, up to user to opt out s390x+jdk8 from input
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7hl': 'armv7hl',
+        'armv7l': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'
     ]
+    // if VERSION is 8 or 20 remove s390x from the list
+    if (VERSION == '8' || VERSION == '20') {
+        rpmArchList.remove('s390x')
+    }
+    // if VERSION is 20 remove armv7hl from the list
+    if (VERSION == '20') {
+        rpmArchList.remove('armv7hl')
+    }
+
     if ("${rpmArch}" != 'all') {
         // when only build and upload one arch, reset
         rpmArchList = [("${rpmArch}" as String): "${rpmArchList[rpmArch]}"]

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -231,7 +231,7 @@ def buildAndTest(String DISTRO, String buildArch) {
             def gBuildTask = (buildArch == 'x86_64') ? "package${TYPE}${DISTRO} check${TYPE}${DISTRO}" : "package${TYPE}${DISTRO}"
             def debArchList = [
                 'x86_64' : 'amd64',
-                'armv7l': 'armhf',
+                'armv7l': 'armv7hl',
                 'aarch64': 'arm64',
                 'ppc64le': 'ppc64el',
                 's390x'  : 's390x'

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
     parameters {
         choice(name: 'TYPE', choices: Types.ALL, description: 'Build JDK or JRE')
         choice(name: 'VERSION', choices: ['8', '11', '17', '20'], description: 'Build for specific JDK VERSION')
-        choice(name: 'ARCH', choices: ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x', 'all'], description: 'Build for specific platform\n s390x not for VERSION 8\n')
+        choice(name: 'ARCH', choices: ['x86_64', 'armv7hl', 'aarch64', 'ppc64le', 's390x', 'all'], description: 'Build for specific platform\n s390x not for VERSION 8\n')
         choice(name: 'DISTRO', choices: ['all', 'Alpine', 'Debian', 'RedHat', 'Suse'], description: 'Build for specific Distro\n Select RPM builds for RedHat and Suse')
         booleanParam(name: 'uploadPackage', defaultValue: false, description: 'Tick this box to upload the deb/rpm files (exclude src.rpm) to Artifactory for official release')
         booleanParam(name: 'uploadSRCRPM', defaultValue: false, description: 'Tick this box to upload (src.rpm files) to Artifactory')
@@ -193,9 +193,6 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') && "${ARCH}" == 'armv7l') {
-      ARCH = 'armv7hl'
-    }
     setup("${DISTRO}", "${ARCH}")
     unstash 'installercode'
     buildAndTest("${DISTRO}", "${ARCH}")
@@ -234,7 +231,7 @@ def buildAndTest(String DISTRO, String buildArch) {
             def gBuildTask = (buildArch == 'x86_64') ? "package${TYPE}${DISTRO} check${TYPE}${DISTRO}" : "package${TYPE}${DISTRO}"
             def debArchList = [
                 'x86_64' : 'amd64',
-                'armv7l': 'armv7hl',
+                'armv7l': 'armhf',
                 'aarch64': 'arm64',
                 'ppc64le': 'ppc64el',
                 's390x'  : 's390x'
@@ -388,7 +385,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7l': 'armv7hl',
+        'armv7hl': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -193,8 +193,8 @@ def jenkinsStepDeb() {
 // function handle both Alpine, RedHat and Suse as DISTRO
 def jenkinsStepNonDeb(String DISTRO) {
     echo "Installer Job for Temurin jdk ${VERSION} - ${ARCH} - ${DISTRO}"
-    if ("${ARCH}" == 'armv7l') {
-        ARCH = 'armv7hl'
+    if (("${DISTRO}" == 'RedHat' || "${DISTRO}" == 'Suse') &&  ("${ARCH}" == 'armv7l')) {
+      ARCH = 'armv7hl'
     }
     setup("${DISTRO}", "${ARCH}")
     unstash 'installercode'

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -363,7 +363,7 @@ def uploadDebArtifacts(String buildArch) {
 
 def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def distro_Package = [
-        'redhat' : [
+        'RedHat' : [
             'rpm/centos/7',
             'rpm/rocky/8',
             'rpm/rhel/7',
@@ -378,7 +378,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
             'rpm/amazonlinux/2'
 
         ],
-        'suse'   : [
+        'Suse'   : [
             'rpm/opensuse/15.3',
             'rpm/opensuse/15.4',
             'rpm/sles/12',
@@ -388,7 +388,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
     def packageDirs = distro_Package[DISTRO.toLowerCase()]
     def rpmArchList=[
         'x86_64' : 'x86_64',
-        'armv7hl': 'armv7hl',
+        'armv7l': 'armv7hl',
         'aarch64': 'aarch64',
         'ppc64le': 'ppc64le',
         's390x'  : 's390x'


### PR DESCRIPTION
Always translate armv7l into armv7hl for RHEL & Suse release packages, to ensure consistency with artifactory.