### PR TITLE
migrate to using jfrog CLI for uploads

### DIFF
--- a/.github/workflows/cacert-publish.yml
+++ b/.github/workflows/cacert-publish.yml
@@ -29,6 +29,12 @@ jobs:
           architecture: x64
           distribution: 'temurin'
 
+      - uses: jfrog/setup-jfrog-cli@v3
+        env:
+          JF_URL: https://packages.adoptium.net
+          JF_USER: ${{ secrets.ARTIFACTORY_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
       - name: Build
         run: |
           export _JAVA_OPTIONS="-Xmx4G"
@@ -39,22 +45,18 @@ jobs:
         run: |
           FILE=$(ls ca-certificates/debian/build/ospackage/*.deb)
           echo "File to upload: ${FILE}"
-          CODE=$(curl -s -o /dev/null -w "%{http_code}\n" https://packages.adoptium.net/artifactory/deb/pool/main/a/adoptium-ca-certificates/$(basename ${FILE}))
-          echo "status=$CODE" >> "$GITHUB_OUTPUT"
-
-      - name: Log Status Code
-        run: echo "Status code ${{ steps.check-deb.outputs.status }}"
+          if jf rt s "deb/pool/main/a/adoptium-ca-certificates/$(basename $FILE)" > /dev/null; then
+            echo file_exists=true >> "$GITHUB_OUTPUT"
+          else
+            echo file_exists=false >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload deb file to Artifactory
-        if: steps.check-deb.outputs.status == '404'
+        if: steps.check-deb.outputs.file_exists == 'false'
         run: |
           debVersionList=("bookworm" "bullseye" "buster" "kinetic" "jammy" "focal" "bionic")
           for debVersion in "${debVersionList[@]}"; do
             distroList+="deb.distribution=${debVersion};"
           done
           FILE=$(ls ca-certificates/debian/build/ospackage/*.deb)
-          curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD} \
-          -X PUT -T $FILE "https://packages.adoptium.net/artifactory/deb/pool/main/a/adoptium-ca-certificates/$(basename ${FILE});deb.architecture=all;deb.component=main;${distroList}"
-        env:
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          jf rt u "$FILE" "deb/pool/main/a/adoptium-ca-certificates/$(basename ${FILE});deb.architecture=all;deb.component=main;${distroList}"

--- a/.github/workflows/cacert-publish.yml
+++ b/.github/workflows/cacert-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_URL: https://packages.adoptium.net
+          JF_URL: https://adoptium.jfrog.io
           JF_USER: ${{ secrets.ARTIFACTORY_USER }}
           JF_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -28,6 +28,9 @@ pipeline {
     agent {
         label NODE_LABEL
     }
+    tools {
+        jfrog 'jfrog-cli'
+    }
     options {
         timeout(time: 2, unit: 'HOURS')
     }
@@ -276,22 +279,8 @@ def uploadArtifacts(String DISTRO, String buildArch) {
 
 def uploadAlpineArtifacts(String buildArch) {
     // currently only support x64 as buildArch
-    rtUpload ( //artifactory plugin
-        serverId: 'adoptium.jfrog.io',
-        failNoOp: true,
-        spec: """{
-            "files": [
-                {
-                "pattern": "**/build/ospackage/temurin-*j*.apk",
-                "target": "apk/alpine/main/${buildArch}/"
-                },
-                {
-                "pattern": "**/build/ospackage/temurin-*src*.apk",
-                "target": "apk/alpine/main/${buildArch}/"
-                }
-            ]
-        }""",
-    )
+    jf rt u "**/build/ospackage/temurin-*j*.apk" "apk/alpine/main/${buildArch}/"
+    jf rt u "**/build/ospackage/temurin-*src*.apk" "apk/alpine/main/${buildArch}/"
 }
 
 def uploadDebArtifacts(String buildArch) {
@@ -340,19 +329,7 @@ def uploadDebArtifacts(String buildArch) {
             */
             sleep 2
         } else {
-            rtUpload( //artifactory plugin
-                serverId: 'adoptium.jfrog.io',
-                failNoOp: true,
-                spec: """{
-                    "files": [
-                        {
-                        "pattern": "**/build/ospackage/temurin-*${debArchList[buildArch]}.deb",
-                        "target": "deb/pool/main/t/temurin-${VERSION}/",
-                        "props": "${distro_list}deb.component=main;deb.architecture=${debArchList[buildArch]}"
-                        }
-                    ]
-                }""",
-            )
+            jf rt u "**/build/ospackage/temurin-*${debArchList[buildArch]}.deb" "deb/pool/main/t/temurin-${VERSION}/" --props="${distro_list}deb.component=main;deb.architecture=${debArchList[buildArch]}"
             break
         }
     }
@@ -419,18 +396,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
                     */
                     sleep 2
                 } else {
-                    rtUpload(
-                        serverId: 'adoptium.jfrog.io',
-                        failNoOp: true,
-                        spec: """{
-                            "files": [
-                                {
-                                "pattern": "**/build/ospackage/*.${entry.value}.rpm",
-                                "target": "${packageDir}/${entry.key}/Packages/"
-                                }
-                            ]
-                        }"""
-                    )
+                    jf rt u "**/build/ospackage/*.${entry.value}.rpm" "${packageDir}/${entry.key}/Packages/"
                     break
                 }
             }


### PR DESCRIPTION
Switching to the CLI should be more stable for uploads. I've already installed and configured the plugin in jenkins.