### PR TITLE
Installer updates for JDK11 & JDK17 for August 2023 respin releases

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.20_p8
+pkgver=11.0.20.1_p1
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
 _pkgvername=${_pkgverplus/+/%2B}
-pkgrel=0
+pkgrel=1
 pkgdesc="Eclipse Temurin 11"
 provider_priority=11
 url="https://adoptium.net"
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-0b7e894af823484f270031ed6626f78504a7a44f8173d67433e14321d015e669  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+1a94e642bf6cc4124d4f01f43184f9127ef994cbd324e2ee42cc50f715cbaedf  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.8_p7
+pkgver=17.0.8.1_p1
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
 _pkgvername=${_pkgverplus/+/%2B}
-pkgrel=0
+pkgrel=1
 pkgdesc="Eclipse Temurin 17"
 provider_priority=17
 url="https://adoptium.net"
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-90eb413eeed9cc2813f7d66d348c35475148c0cdc41c8f9ef2f26d51078e287e  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+85d298268db61c4a538df905ec510eba7dc09300e7f7132bb2e25e5e8aef1933  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jdk (11.0.20.1.0+1) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.20.1.0+1release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 31 Aug 2023 08:00:00 +0000
+
 temurin-11-jdk (11.0.20.0.0+8) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.20.0.0+8 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jdk
 priority = 1111
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200 jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20_8.tar.gz
-amd64_checksum = 7a99258af2e3ee9047e90f1c0c1775fd6285085759501295358d934d662e01f9
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20_8.tar.gz
-arm64_checksum = eb821c049c2d2f7c3fbf8ddcce2d608d3aa7d488700e76bfbbebabba93021748
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.20_8.tar.gz
-armhf_checksum = fdf98d94ac3fd49a73a534fd88cf60e757e885c04791d15f76ccfcecb43a25e0
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.20_8.tar.gz
-ppc64el_checksum = 1125931b3a38e6e305a1932fc6cfd0b023a0fbec2cab10e835a2ee2c50848b42
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.20_8.tar.gz
-s390x_checksum = 688c83d9edf2204220df94ce5bab4a6d19f3d91bc0e500f31dda41e16d9a383f
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20.1_1.tar.gz
+amd64_checksum = 398a64bff002f0e3b0c01ecd24a1a32c83cb72a5255344219e9757d4ddd9f857
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20.1_1.tar.gz
+arm64_checksum = 69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_arm_linux_hotspot_11.0.20.1_1.tar.gz
+armhf_checksum = e83674aee238ebb5f359b9395b3c5e3fad5b645846095494662802d2f0fd01c9
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.20.1_1.tar.gz
+ppc64el_checksum = b806f4bb526161bf9b2ffb37be4e1b77f56b4e726dc4d52c7902130a79e7d710
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.20.1_1.tar.gz
+s390x_checksum = a7efbe804a4616d38b6ac0def40cd9feacc04aee2bb89132191f4d33fc0a7c1e
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jdk (17.0.8.1.0+1) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.8.1.0+1 release.
+
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 31 Aug 2023 08:00:00 +0000
+
 temurin-17-jdk (17.0.8.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.8.0.0+7 release.
@@ -15,7 +21,7 @@ temurin-17-jdk (17.0.6.0.0+10) STABLE; urgency=medium
   * Eclipse Temurin 17.0.6.0.0+10 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 18 Jan 2023 09:43:20 +0000
- 
+
 temurin-17-jdk (17.0.5.0.0+8-1) STABLE; urgency=medium
 
   * Add Ubuntu Kinetic (22.10) to the list of supported Ubuntu releases.
@@ -33,13 +39,13 @@ temurin-17-jdk (17.0.4.1.0+1) STABLE; urgency=medium
   * Eclipse Temurin 17.0.4.1.0+1 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 23 Aug 2022 17:38:30 +0000
- 
+
 temurin-17-jdk (17.0.4.0.0+8) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.4.0.0+8 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 27 Jul 2022 17:38:30 +0000
- 
+
 temurin-17-jdk (17.0.3.0.0+7) UNRELEASED; urgency=medium
 
   * Eclipse Temurin 17.0.3.0.0+7 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jdk
 priority = 1711
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8_7.tar.gz
-amd64_checksum = aa5fc7d388fe544e5d85902e68399d5299e931f9b280d358a3cbee218d6017b0
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8_7.tar.gz
-arm64_checksum = c43688163cfdcb1a6e6fe202cc06a51891df746b954c55dbd01430e7d7326d00
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8_7.tar.gz
-armhf_checksum = 33d972efd78b70a07aed793a6ebcb52a5129707e8c62268e478d1c2df15898e1
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8_7.tar.gz
-ppc64el_checksum = 88f5d14cc84a4bcfe50aa275092ae97a0edf7205269ed12c1972bf613bc52b1e
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8_7.tar.gz
-s390x_checksum = 055d8bd0eebf137cf3506fb84817ce2d858597f21067d9a1268f08916738b435
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz
+amd64_checksum = c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz
+arm64_checksum = eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8.1_1.tar.gz
+armhf_checksum = b1f1d8b7fcb159a0a8029b6c3106d1d16207cecbb2047f9a4be2a64d29897da5
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz
+ppc64el_checksum = 00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8.1_1.tar.gz
+s390x_checksum = ffacba69c6843d7ca70d572489d6cc7ab7ae52c60f0852cedf4cf0d248b6fc37
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.20+8
+%global upstream_version 11.0.20.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.20.0.0.8
+%global spec_version 11.0.20.1.0.1
 %global spec_release 1
 %global priority 1111
 
@@ -264,6 +264,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.1.0.1-1
+- Eclipse Temurin 11.0.20.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8-1
 - Eclipse Temurin 11.0.20+8 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-2

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.8+7
+%global upstream_version 17.0.8.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.8.0.0.7
+%global spec_version 17.0.8.1.0.1
 %global spec_release 1
 %global priority 1161
 
@@ -261,6 +261,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.1.0.1-1
+- Eclipse Temurin 17.0.8.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7-1
 - Eclipse Temurin 17.0.8+7 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-2

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.20+8
+%global upstream_version 11.0.20.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.20.0.0.8
+%global spec_version 11.0.20.1.0.1
 %global spec_release 1
 %global priority 1111
 
@@ -255,6 +255,8 @@ fi
 %{prefix}
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.1.0.1-1
+- Eclipse Temurin 11.0.20.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8-1
 - Eclipse Temurin 11.0.20+8 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-2

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,9 +1,9 @@
-%global upstream_version 17.0.8+7
+%global upstream_version 17.0.8.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
-%global spec_version 17.0.8.0.0.7
+%global spec_version 17.0.8.1.0.1
 %global spec_release 1
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global priority 1161
@@ -251,6 +251,8 @@ fi
 %{prefix}
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.1.0.1-1
+- Eclipse Temurin 17.0.8.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7-1
 - Eclipse Temurin 17.0.8+7 release.
 * Thu May 4 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-2

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.20_p8
+pkgver=11.0.20.1_p1
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
 _pkgvername=${_pkgverplus/+/%2B}
-pkgrel=0
+pkgrel=1
 pkgdesc="Eclipse Temurin 11"
 provider_priority=11
 url="https://adoptium.net"
@@ -72,5 +72,5 @@ _jre() {
 }
 
 sha256sums="
-ad1645501461a986f6f40ede6a76198f267c694c06150a9ed36ae95e7d012287  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+d34ea3d1e3852548546c69d7d73addb873e7926e66147b8596b7c11fad9ee057  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.8_p7
+pkgver=17.0.8.1_p1
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
 _pkgvername=${_pkgverplus/+/%2B}
-pkgrel=0
+pkgrel=1
 pkgdesc="Eclipse Temurin 17"
 provider_priority=17
 url="https://adoptium.net"
@@ -71,5 +71,5 @@ _jre() {
 }
 
 sha256sums="
-4cdf34da04fe3ed705c6ca0281049baa9f772e6321a77fe395023fb8e41fdb9f  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+bf726bb99785901f22849a0ef4ddd4e67f3e5b184dbbf260fffbaf5befce18a3  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jre (11.0.20.1.0+1) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.20.1.0+1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 31 Aug 2023 08:00:00 +0000
+
 temurin-11-jre (11.0.20.0.0+8) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.20.0.0+8 release.

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jre
 priority = 1112
 jvm_tools = jaotc java jfr jjs jrunscript keytool pack200 rmid rmiregistry unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_x64_linux_hotspot_11.0.20_8.tar.gz
-amd64_checksum = ffb070c26ea22771f78769c569c9db3412e6486434dc6df1fd3c3438285766e7
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.20_8.tar.gz
-arm64_checksum = 45e190920fb3ec61ee5213a7bd98553abf2ae7692eb9daa504fcdc9d59a7cfc4
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_arm_linux_hotspot_11.0.20_8.tar.gz
-armhf_checksum = 1e2a02364084b2d054e88a871f3efaa4450ae4f087b8f806fd95c15d5affcc7b
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.20_8.tar.gz
-ppc64el_checksum = 61034834b61bf080392218b25dcac2d9e3505b5e4f53539704d496be4181aadf
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20+8/OpenJDK11U-jre_s390x_linux_hotspot_11.0.20_8.tar.gz
-s390x_checksum = 0c7050976914e0613179446de62bb20d2845ae809f6d31bc0ed8d136f8fd3d9b
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_x64_linux_hotspot_11.0.20.1_1.tar.gz
+amd64_checksum = bc6ed047e50b09611b419c878e4ea3ea36594bd79f64001a5b53decf72669d33
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.20.1_1.tar.gz
+arm64_checksum = 0f69f5c05cb7fb2804be3735ed31ce92acff1a51ef29be544b89f83c90d2ea2a
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_arm_linux_hotspot_11.0.20.1_1.tar.gz
+armhf_checksum = 2fc1cc935897312c0bc2515b2e7ea1fa3b267e77305a1b51a8c3917d92af380f
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.20.1_1.tar.gz
+ppc64el_checksum = 7963580e5c3abe55e6b9d2297f2e2cde7b227d28204497bec5f17bb37762c7b7
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1+1/OpenJDK11U-jre_s390x_linux_hotspot_11.0.20.1_1.tar.gz
+s390x_checksum = cf7fa0f0291687ebcb5f87f5db3a8d94525fd65832adc636c4c6e1f3174d9997
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,9 +1,15 @@
+temurin-17-jre (17.0.8.1.0+1) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.8.1.0+1 release.
+
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 31 Aug 2023 08:00:00 +0000
+
 temurin-17-jre (17.0.8.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.8.0.0+7 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
- 
+
 temurin-17-jre (17.0.7+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.7.0.0+7 release.

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jre
 priority = 1712
 jvm_tools = java jfr jrunscript keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_x64_linux_hotspot_17.0.8_7.tar.gz
-amd64_checksum = dddbb5f817a77445711528a414678806b00b83c92701fe595c50cdb207758ae9
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.8_7.tar.gz
-arm64_checksum = 42525ae2951a669803c75ba5987dc8333c664dae50c3e12174f736a506b4aa15
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_arm_linux_hotspot_17.0.8_7.tar.gz
-armhf_checksum = 20fa06a86e1647f5997c511dd19e4d1c9839d2500f835973fc9b3c86b87030a0
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.8_7.tar.gz
-ppc64el_checksum = 1cf2cf7dca98c74860799b162b9f2eeaaf1ad1e78f5cb7479fe7bd1ccfea3227
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8+7/OpenJDK17U-jre_s390x_linux_hotspot_17.0.8_7.tar.gz
-s390x_checksum = 4df17b19510864651c1d620baaf13766a448d43ee7848ea9ff69db10d26467b6
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jre_x64_linux_hotspot_17.0.8.1_1.tar.gz
+amd64_checksum = ab68857594792474a3049ede09ea1178e42df29803a6a41be771794f571b2d4e
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.8.1_1.tar.gz
+arm64_checksum = 0a1c5c9ee9d20832c87bd1e99a4c4a96947b59bb35c72683fe895d705f202737
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jre_arm_linux_hotspot_17.0.8.1_1.tar.gz
+armhf_checksum = 8af898c5d356f0b2cee2db67ff9c8e7a8e738c0f6b3a61c383150b3168b9ea58
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz
+ppc64el_checksum = 53f064e32e19072e940b3450d8af1fd447f2c036477890688fcb7249f1e6bfb9
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jre_s390x_linux_hotspot_17.0.8.1_1.tar.gz
+s390x_checksum = 5eff8141fd282b3473fd649e04c113ba044cf19f0c513b951b700c28a81c1d6a
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.20+8
+%global upstream_version 11.0.20.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.20.0.0.8
+%global spec_version 11.0.20.1.0.1
 %global spec_release 1
 %global priority 1112
 
@@ -199,6 +199,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.1.0.1-1
+- Eclipse Temurin 11.0.20.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8-1
 - Eclipse Temurin 11.0.20+8 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-1

--- a/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.8+7
+%global upstream_version 17.0.8.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.8.0.0.7
+%global spec_version 17.0.8.1.0.1
 %global spec_release 1
 %global priority 1712
 
@@ -186,6 +186,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.1.0.1-1
+- Eclipse Temurin 17.0.8.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7-1
 - Eclipse Temurin 17.0.8+7 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-1

--- a/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.20+8
+%global upstream_version 11.0.20.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.20.0.0.8
+%global spec_version 11.0.20.1.0.1
 %global spec_release 1
 %global priority 1112
 
@@ -190,6 +190,8 @@ fi
 %{prefix}
 
 %changelog
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.1.0.1-1
+- Eclipse Temurin 11.0.20.1+1 release.
 * Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.20.0.0.8-1
 - Eclipse Temurin 11.0.20+8 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.19.0.0.7-1

--- a/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.8+7
+%global upstream_version 17.0.8.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.8.0.0.7
+%global spec_version 17.0.8.1.0.1
 %global spec_release 1
 %global priority 1712
 
@@ -176,8 +176,8 @@ fi
 %{prefix}
 
 %changelog
-* Tue Jul 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.0.0.7-1
-- Eclipse Temurin 17.0.8+7 release.
+* Thu Aug 31 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.8.1.0.1-1
+- Eclipse Temurin 17.0.8.1+1 release.
 * Wed Apr 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.7.0.0.7-1
 - Eclipse Temurin JRE 17.0.7+7 release.
 * Wed Feb 22 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.6.0.0.10-2


### PR DESCRIPTION
Update APK, deb and rpm spec files for release.