### PR TITLE
removed ubuntu 22.10 support due to EoL

### DIFF
--- a/.github/workflows/cacert-publish.yml
+++ b/.github/workflows/cacert-publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload deb file to Artifactory
         if: steps.check-deb.outputs.file_exists == 'false'
         run: |
-          debVersionList=("bookworm" "bullseye" "buster" "kinetic" "jammy" "focal" "bionic")
+          debVersionList=("bookworm" "bullseye" "buster" "jammy" "focal" "bionic")
           for debVersion in "${debVersionList[@]}"; do
             distroList+="deb.distribution=${debVersion};"
           done

--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -317,7 +317,6 @@ def uploadDebArtifacts(String buildArch) {
             "bookworm", // Debian/12
             "bullseye", // Debian/11
             "buster",   // Debian/10
-            "kinetic",  // Ubuntu/22.10
             "jammy",    // Ubuntu/22.04 (LTS)
             "focal",    // Ubuntu/20.04 (LTS)
             "bionic",   // Ubuntu/18.04 (LTS)

--- a/linux/README.md
+++ b/linux/README.md
@@ -202,7 +202,6 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 | debian/12 (bookworm/testing) |         x86_64         |      |
 | debian/11 (bullseye/stable)  |         x86_64         |      |
 | debian/10 (buster/oldstable) |         x86_64         |      |
-| ubuntu/22.10 (kinetic)       |         x86_64         |      |
 | ubuntu/22.04 (jammy)         |         x86_64         |      |
 | ubuntu/20.04 (focal)         |         x86_64         |      |
 | ubuntu/18.04 (bionic)        |         x86_64         |      |

--- a/linux/ca-certificates/debian/build.gradle
+++ b/linux/ca-certificates/debian/build.gradle
@@ -28,7 +28,6 @@ def deb_versions = [
 		"bookworm", // Debian/12
 		"bullseye", // Debian/11
 		"buster",   // Debian/10
-		"kinetic",  // Ubuntu/22.10
 		"jammy",    // Ubuntu/22.04 (LTS)
 		"focal",    // Ubuntu/20.04 (LTS)
 		"bionic",   // Ubuntu/18.04 (LTS)

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
@@ -35,7 +35,6 @@ class ChangesVerificationTest {
 			"bookworm", // Debian/12
 			"bullseye", // Debian/11
 			"buster",   // Debian/10
-			"kinetic",  // Ubuntu/22.10
 			"jammy",    // Ubuntu/22.04 (LTS)
 			"focal",    // Ubuntu/20.04 (LTS)
 			"bionic",   // Ubuntu/18.04 (LTS)

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
@@ -38,7 +38,6 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of("debian", "bookworm"), // Debian/12 (testing)
 			Arguments.of("debian", "bullseye"), // Debian/11 (stable)
 			Arguments.of("debian", "buster"),   // Debian/10 (oldstable)
-			Arguments.of("ubuntu", "kinetic"),  // Ubuntu/22.10
 			Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 			Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)
 			Arguments.of("ubuntu", "bionic")    // Ubuntu/18.04 (LTS)

--- a/linux/jdk/debian/src/main/packaging/build.sh
+++ b/linux/jdk/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="bookworm bullseye buster kinetic jammy focal bionic"
+debVersionList="bookworm bullseye buster jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -39,7 +39,6 @@ public class DebianFlavours implements ArgumentsProvider {
                 Arguments.of("debian", "bookworm"), // Debian/12 (testing)
                 Arguments.of("debian", "bullseye"), // Debian/11 (stable)
                 Arguments.of("debian", "buster"),   // Debian/10 (oldstable)
-                Arguments.of("ubuntu", "kinetic"),  // Ubuntu/22.10
                 Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
                 Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)
                 Arguments.of("ubuntu", "bionic")    // Ubuntu/18.04 (LTS)

--- a/linux/jre/debian/src/main/packaging/build.sh
+++ b/linux/jre/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="bookworm bullseye buster kinetic jammy focal bionic"
+debVersionList="bookworm bullseye buster jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -39,7 +39,6 @@ public class DebianFlavours implements ArgumentsProvider {
 				Arguments.of("debian", "bookworm"), // Debian/12 (testing)
 				Arguments.of("debian", "bullseye"), // Debian/11 (stable)
 				Arguments.of("debian", "buster"),   // Debian/10 (oldstable)
-				Arguments.of("ubuntu", "kinetic"),  // Ubuntu/22.10
 				Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 				Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)
 				Arguments.of("ubuntu", "bionic")    // Ubuntu/18.04 (LTS)


### PR DESCRIPTION
This fixes the failures in the PR automated checks due to ubuntu 22.10's end of life