### PR TITLE
Installers: Remove PPC64LE for JDK21+35 RHEL & SUSE

### DIFF
--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -88,11 +88,11 @@ Provides: java-sdk-21-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -24,13 +24,13 @@
 %global src_num 0
 %global sha_src_num 1
 %endif
-%ifarch ppc64le
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global src_num 2
-%global sha_src_num 3
-%endif
+# %ifarch ppc64le
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global src_num 2
+# %global sha_src_num 3
+# %endif
 %ifarch aarch64
 %global vers_arch x64
 %global vers_arch2 ppc64le
@@ -100,8 +100,8 @@ Provides: java-sdk-%{java_provides}
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+# Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -19,7 +19,7 @@
 
 %ifarch x86_64
 %global vers_arch x64
-%global vers_arch2 ppc64le
+# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
@@ -33,7 +33,7 @@
 # %endif
 %ifarch aarch64
 %global vers_arch x64
-%global vers_arch2 ppc64le
+# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -19,21 +19,12 @@
 
 %ifarch x86_64
 %global vers_arch x64
-# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
 %endif
-# %ifarch ppc64le
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global src_num 2
-# %global sha_src_num 3
-# %endif
 %ifarch aarch64
 %global vers_arch x64
-# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5
@@ -99,9 +90,6 @@ Provides: java-sdk-%{java_provides}
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Second architecture (ppc64le)
-# Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-# Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -18,7 +18,7 @@
 
 %ifarch x86_64
 %global vers_arch x64
-%global vers_arch2 ppc64le
+# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
@@ -32,7 +32,7 @@
 # %endif
 %ifarch aarch64
 %global vers_arch x64
-%global vers_arch2 ppc64le
+# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -87,11 +87,11 @@ Provides: java-sdk-21-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -23,13 +23,13 @@
 %global src_num 0
 %global sha_src_num 1
 %endif
-%ifarch ppc64le
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global src_num 2
-%global sha_src_num 3
-%endif
+# %ifarch ppc64le
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global src_num 2
+# %global sha_src_num 3
+# %endif
 %ifarch aarch64
 %global vers_arch x64
 %global vers_arch2 ppc64le

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -18,21 +18,12 @@
 
 %ifarch x86_64
 %global vers_arch x64
-# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
 %endif
-# %ifarch ppc64le
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global src_num 2
-# %global sha_src_num 3
-# %endif
 %ifarch aarch64
 %global vers_arch x64
-# %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5
@@ -98,9 +89,6 @@ Provides: java-sdk-%{java_provides}
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Second architecture (ppc64le)
-#Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-#Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21u-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -18,21 +18,12 @@
 
 %ifarch x86_64
 %global vers_arch x64
-%global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
 %endif
-%ifarch ppc64le
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global src_num 2
-%global sha_src_num 3
-%endif
 %ifarch aarch64
 %global vers_arch x64
-%global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5
@@ -88,9 +79,6 @@ Provides: jre-%{java_provides}-headless
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Second architecture (ppc64le)
-#Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-#Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -77,11 +77,11 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -18,21 +18,12 @@
 
 %ifarch x86_64
 %global vers_arch x64
-%global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 0
 %global sha_src_num 1
 %endif
-%ifarch ppc64le
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global src_num 2
-%global sha_src_num 3
-%endif
 %ifarch aarch64
 %global vers_arch x64
-%global vers_arch2 ppc64le
 %global vers_arch3 aarch64
 %global src_num 4
 %global sha_src_num 5
@@ -88,9 +79,6 @@ Provides: jre-%{java_provides}-headless
 # First architecture (x86_64)
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Second architecture (ppc64le)
-#Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-#Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -77,11 +77,11 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}


### PR DESCRIPTION
Remove PPC64LE for JDK21+35 RHEL & SUSE to allow release of x64 and arm64

Also correct issue with lowercase U in spec files.