### PR TITLE
Fix JDK17.0.9 Debian Version Numbers In The Changelog

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,6 +1,6 @@
-temurin-17-jdk (17.0.9.0+9) STABLE; urgency=medium
+temurin-17-jdk (17.0.9.0.0+9) STABLE; urgency=medium
 
-  * Eclipse Temurin 17.0.9.0.+9 release.
+  * Eclipse Temurin 17.0.9.0.0+9 release.
 
   -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 26 Oct 2023 08:00:00 +0000
   

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,6 +1,6 @@
-temurin-17-jre (17.0.9.0+9) STABLE; urgency=medium
+temurin-17-jre (17.0.9.0.0+9) STABLE; urgency=medium
 
-  * Eclipse Temurin 17.0.9.0.+9 release.
+  * Eclipse Temurin 17.0.9.0.0+9 release.
 
   -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 26 Oct 2023 08:00:00 +0000
 


### PR DESCRIPTION
Fix JDK17.0.9 Debian Version Numbers In The Changelog

Updated from 17.0.9.0+9 to 17.0.9.0.0+9