### PR TITLE
Add OpenSuSE 15.5 as a supported distribution

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -464,6 +464,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch) {
         'suse'   : [
             'rpm/opensuse/15.3',
             'rpm/opensuse/15.4',
+            'rpm/opensuse/15.5',
             'rpm/sles/12',
             'rpm/sles/15'
         ]

--- a/linux/README.md
+++ b/linux/README.md
@@ -229,6 +229,7 @@ SRPM also available.
 | oraclelinux/8 |         x86_64         |                                             |
 | opensuse/15.3 |         x86_64         |                                             |
 | opensuse/15.4 |         x86_64         |                                             |
+| opensuse/15.5 |         x86_64         |                                             |
 | rocky/8       |         x86_64         |                                             |
 | rpm/rhel/7    |         x86_64         |                                             |
 | rpm/rhel/8    |         x86_64         |                                             |

--- a/linux/jdk/suse/src/main/packaging/Dockerfile
+++ b/linux/jdk/suse/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 
 RUN zypper update -y && zypper install -y rpm-build \
 	rpm-devel \

--- a/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
+++ b/linux/jdk/suse/src/packageTest/java/packaging/SuseFlavours.java
@@ -37,6 +37,7 @@ public class SuseFlavours implements ArgumentsProvider {
 		return Stream.of(
 			Arguments.of("opensuse/leap", "15.3"),
 			Arguments.of("opensuse/leap", "15.4"),
+			Arguments.of("opensuse/leap", "15.5"),
 			Arguments.of("registry.suse.com/suse/sles12sp5", "latest"),
 			Arguments.of("registry.suse.com/suse/sle15", "latest")
 		);

--- a/linux/jre/suse/src/main/packaging/Dockerfile
+++ b/linux/jre/suse/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 
 RUN zypper update -y && zypper install -y rpm-build \
 	rpm-devel \

--- a/linux/jre/suse/src/packageTest/java/packaging/SuseFlavours.java
+++ b/linux/jre/suse/src/packageTest/java/packaging/SuseFlavours.java
@@ -37,6 +37,7 @@ public class SuseFlavours implements ArgumentsProvider {
 		return Stream.of(
 			Arguments.of("opensuse/leap", "15.3"),
 			Arguments.of("opensuse/leap", "15.4"),
+			Arguments.of("opensuse/leap", "15.5"),
 			Arguments.of("registry.suse.com/suse/sles12sp5", "latest"),
 			Arguments.of("registry.suse.com/suse/sle15", "latest")
 		);


### PR DESCRIPTION
This is in draft while it's undergoing testing, but this adds support for OpenSuSE 15.5 - the current verison - into our packaging process to ensure that users using that distribution can follow the installation instructions without modification on the latest patch level. Note that this also adjusts the process to build the package on OpenSuSE 15.5 instead of 15.4 as the base image.

Potential alternative options:
- Add 15.6 which is available alpha for OpenSuSE 
- Remove 15.3 (out of support Dec 2022) to keep the number of distributions at 2, and potentially also rmove 15.4 since that is also out of support as of December 2023

Draft until I ensure it can be built successfully.

Fixes https://github.com/adoptium/installer/issues/792