### PR TITLE
Reinstate libfreetype install on JDK21

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
@@ -59,9 +59,6 @@ override_dh_auto_install:
 	# Add jinfo file (alternatives support).
 	cp debian/jinfo "$(d)/$(jvm_home)/.$(pkg_alias).jinfo"
 
-	# Strip bundled Freetype and use OS package instead.
-	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/libfreetype.so"
-
 	# Replace bundled cacerts and redirect to adoptium-ca-certificates.
 	rm -f "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"
 	ln -s /etc/ssl/certs/adoptium/cacerts "$(d)/$(jvm_home)/$(jvm_dir)/lib/security/cacerts"

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -135,9 +135,6 @@ mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
 
-# Strip bundled Freetype and use OS package instead.
-rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"
-
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
 pushd "%{buildroot}%{prefix}/lib/security"

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -128,9 +128,6 @@ mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
 
-# Strip bundled Freetype and use OS package instead.
-rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"
-
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
 pushd "%{buildroot}%{prefix}/lib/security"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3624#issuecomment-1915272320 (hopefully!)

Note that I haven't adjusted `redhat/src/main/packaging/microsoft/21/msopenjdk-21.spec` which still has the `rm`

I have not tested this, so if a review can fdire off a test and see if the package contains `libfreetype.so` after this then that would be appreciated.