### PR TITLE
Bump RPM spec & Debian versions to JDK21.0.2.0.0+13-2

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,15 +1,21 @@
+temurin-21-jdk (21.0.2.0.0+13-2) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.2.0.0+13-2 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 21 Feb 2024 00:00:00 +0000
+
 temurin-21-jdk (21.0.2.0.0+13) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.2.0.0+13 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 23 Jan 2024 00:00:00 +0000
- 
+
 temurin-21-jdk (21.0.1.0.0+12) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.1.0.0+12 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 24 Oct 2023 11:59:00 +0000
- 
+
 temurin-21-jdk (21.0.0.0.0+35) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.0.0.0+35 release.

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  21.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -223,6 +223,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
+- Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Oct 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.1.0.0.12-1

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  21.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 1
+%global spec_release 2
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -212,6 +212,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
+- Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Oct 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.1.0.0.12-1

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,3 +1,9 @@
+temurin-21-jre (21.0.2.0.0+13-2) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.2.0.0+13-2 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 21 Feb 2024 00:00:00 +0000
+
 temurin-21-jre (21.0.2.0.0+13) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.2.0.0+13 release.

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 1
+%global spec_release 2
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -157,6 +157,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
+- Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Oct 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.1.0.0.12-1

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 1
+%global spec_release 2
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -147,6 +147,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
+- Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Oct 24 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.1.0.0.12-1


### PR DESCRIPTION
Fixes #823 

Bump the RPM spec, and the debian version numbers to allow an update to include the freetype library fix, made as part of https://github.com/adoptium/installer/pull/812