### PR TITLE
Add Installers Support For JDK/JRE 21 s390x Linux ( Debian, RHEL , Suse )

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/control
@@ -6,7 +6,6 @@ Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-21-jdk
 Architecture: amd64 arm64 ppc64el s390x
-
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/control
@@ -5,7 +5,8 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-21-jdk
-Architecture: amd64 arm64 ppc64el
+Architecture: amd64 arm64 ppc64el s390x
+
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
@@ -9,6 +9,8 @@ arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/down
 arm64_checksum = 3ce6a2b357e2ef45fd6b53d6587aa05bfec7771e7fb982f2c964f6b771b7526a
 ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.2_13.tar.gz
 ppc64el_checksum = d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f
+s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.2_13.tar.gz
+s390x_checksum = 0d5676c50821e0d0b951bf3ffd717e7a13be2a89d8848a5c13b4aedc6f982c78
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -21,6 +21,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -28,6 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -35,8 +37,17 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global src_num 6
+%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -58,7 +69,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -105,6 +116,9 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -117,8 +117,8 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_ar
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fourth architecture (s390x)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -27,6 +28,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -34,8 +36,17 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global src_num 6
+%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -57,7 +68,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -104,6 +115,9 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/control
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-21-jre
-Architecture: amd64 arm64 ppc64el
+Architecture: amd64 arm64 ppc64el s390x
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
@@ -9,6 +9,8 @@ arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/down
 arm64_checksum = 64c78854184c92a4da5cda571c8e357043bfaf03a03434eef58550cc3410d8a4
 ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.2_13.tar.gz
 ppc64el_checksum = caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22
+s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_s390x_linux_hotspot_21.0.2_13.tar.gz
+s390x_checksum = ff8191fa5b23a175932e7f4fab10a6e8df61fd71b6529c7d21451c81e82f8d55
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -100,8 +100,8 @@ Provides: jre-%{java_provides}-headless
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -27,6 +28,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -34,8 +36,17 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global src_num 6
+%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -57,7 +68,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -94,6 +105,9 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -100,8 +100,8 @@ Provides: jre-%{java_provides}-headless
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -27,6 +28,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -34,8 +36,17 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global src_num 6
+%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -57,7 +68,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -94,6 +105,9 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}


### PR DESCRIPTION
Fixes #826 

Since JDK21 is now supported on s390x, the linux packages process needs updating to support this.

These changes have been tested as dry runs in my test pipeline (https://ci.adoptium.net/job/doptium-packages-linux-pipeline_new-scottfryer/)

These will be published for s390x for the first time , as part of the spec -2 version, which has the freetype fix, see #823  & #824  