### PR TITLE
Bump RPM for JRE21/ppc64le RHEL & SUSE versions to JDK21.0.2.0.0+13-3 

### DIFF
--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 2
+%global spec_release 3
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -171,6 +171,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Feb 28 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-3
+- Eclipse Temurin 21.0.2+13 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -5,7 +5,7 @@
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
 %global spec_version 21.0.2.0.0.13
-%global spec_release 2
+%global spec_release 3
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -161,6 +161,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Feb 28 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-3
+- Eclipse Temurin 21.0.2+13 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1


### PR DESCRIPTION
Fixes #830 

Following the bug and fix identified and carried out, the spec version for jre21 RHEL & SUSE on ppc64le requires a bump to allow those packages to be republished.