### PR TITLE
Update Main.wxs.template

### DIFF
--- a/wix/Main.wxs.template
+++ b/wix/Main.wxs.template
@@ -133,7 +133,6 @@
         <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\{vendor}.jarfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaw.exe&quot; -jar &quot;%1&quot; %*" KeyPath="no" />
       </Component>
       <Component Id="SetOracleJavaSoftKeysCurrentVersion" Guid="*">
-          <Condition><![CDATA[NOT JAVASOFT_CURRENTVERSION OR JAVASOFT_CURRENTVERSION <> "1.8" AND JAVASOFT_CURRENTVERSION < $(var.ProductMajorVersion)]]></Condition>
           <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\$(var.OracleJavasoftBaseKey)" Name="CurrentVersion" Type="string" Value="$(var.OracleVersionKey)" KeyPath="yes" />
       </Component>
       <Component Id="SetOracleJavaSoftKeys" Guid="*">


### PR DESCRIPTION
Removed the JavaSoftCurrentVersion component condition.

Temurin 8 JavaSoftCurrentVersion key is not removed at uninstall, because the condition is never satisfied. For Temurin 11, 17, etc, the condition doesn't make any sense because it's comparing with version "1.8" and it's always true, and Temurin 8 has totally different keys anyways.