### PR TITLE
Update JDK22 Installer files for JDK22+36 Release

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/22/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/22/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-22
-pkgver=22.0.0_p0
+pkgver=22_p36
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -97,10 +97,10 @@ _jdk() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="f1aef3652dd52778e81eb4897a88a34e38ca0159d22f160f7205e69907a0f14d"
+		_arch_sum="f88fbe6360276cc9aec406802838ff0cfb368e08c2b1cf7b6fa78a846266a7af"
 		;;
 	aarch64)
-		_arch_sum="ae933ea8eeb4a077f19277842ba95ba93d29177e44d53cec7a98afd3b9abb2c3"
+		_arch_sum="e6c97db54afe145a8f93f9ca728b4df8a0490a45f0f999999c7464c64612e936"
 		;;
 esac
 

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jdk
-Architecture: amd64 arm64 ppc64el s390x
+Architecture: amd64 arm64 ppc64el
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
@@ -8,8 +8,8 @@ amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/down
 amd64_checksum = bc3d99e816d0c373f424cd7aa2b6d3e8081a7189fe55c1561616922200ec8e47
 arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_aarch64_linux_hotspot_22_36.tar.gz
 arm64_checksum = 4b52670caea44848cee893e35c804380817b6eff166cf64ee70ca2bfaac3d1c7
-TO_DO_ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.0_0.tar.gz
-TO_DO_ppc64el_checksum = d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f
+ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_ppc64le_linux_hotspot_22_36.tar.gz
+ppc64el_checksum = 8c062e934d95c639f97b4e51b968eed694a6653248727c3db8bc5e0e55cfd7f4
 
 
 d = debian/$(pkg_name)

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
@@ -11,7 +11,6 @@ arm64_checksum = 4b52670caea44848cee893e35c804380817b6eff166cf64ee70ca2bfaac3d1c
 ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_ppc64le_linux_hotspot_22_36.tar.gz
 ppc64el_checksum = 8c062e934d95c639f97b4e51b968eed694a6653248727c3db8bc5e0e55cfd7f4
 
-
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm
 jvm_dir = $(pkg_name)-$(DEB_HOST_ARCH)

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
@@ -3,14 +3,14 @@
 pkg_name = temurin-22-jdk
 priority = 2211
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd jwebserver keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_x64_linux_hotspot_22.0.0_0.tar.gz
-amd64_checksum = 454bebb2c9fe48d981341461ffb6bf1017c7b7c6e15c6b0c29b959194ba3aaa5
-arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.0_0.tar.gz
-arm64_checksum = 3ce6a2b357e2ef45fd6b53d6587aa05bfec7771e7fb982f2c964f6b771b7526a
-ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.0_0.tar.gz
-ppc64el_checksum = d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f
-s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_s390x_linux_hotspot_22.0.0_0.tar.gz
-s390x_checksum = 0d5676c50821e0d0b951bf3ffd717e7a13be2a89d8848a5c13b4aedc6f982c78
+
+amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_x64_linux_hotspot_22_36.tar.gz
+amd64_checksum = bc3d99e816d0c373f424cd7aa2b6d3e8081a7189fe55c1561616922200ec8e47
+arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_aarch64_linux_hotspot_22_36.tar.gz
+arm64_checksum = 4b52670caea44848cee893e35c804380817b6eff166cf64ee70ca2bfaac3d1c7
+TO_DO_ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.0_0.tar.gz
+TO_DO_ppc64el_checksum = d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f
+
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -3,10 +3,10 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
-#  22.0.0.0.0___1 == 22.0.0.0.0+35
-%global spec_version 22.0.0.0.0.0
+#  22.0.0.0.0___1 == 22.0.0.0.0+36
+%global spec_version 22.0.0.0.0.36
 %global spec_release 1
-%global priority 1161
+%global priority 2200
 
 %global source_url_base https://github.com/adoptium/temurin22-binaries/releases/download
 %global upstream_version_url %(echo %{upstream_version} | sed 's/\+/%%2B/g')
@@ -21,7 +21,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -29,7 +28,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -37,17 +35,8 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
-%endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global src_num 6
-%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -69,7 +58,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x
+ExclusiveArch: x86_64 ppc64le aarch64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -116,9 +105,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353
@@ -237,5 +223,5 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.0-0
+* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -104,9 +104,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -3,10 +3,10 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
-#  22.0.0.0.0___1 == 22.0.0.0.0+35
-%global spec_version 22.0.0.0.0.0
+#  22.0.0.0.0___1 == 22.0.0.0.0+36
+%global spec_version 22.0.0.0.0.36
 %global spec_release 1
-%global priority 1161
+%global priority 2200
 
 %global source_url_base https://github.com/adoptium/temurin22-binaries/releases/download
 %global upstream_version_url %(echo %{upstream_version} | sed 's/\+/%%2B/g')
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -28,7 +27,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -36,17 +34,8 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
-%endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global src_num 6
-%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -68,7 +57,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x
+ExclusiveArch: x86_64 ppc64le aarch64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -226,5 +215,5 @@ fi
 %{prefix}
 
 %changelog
-* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.0-0
+* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jre/alpine/src/main/packaging/temurin/22/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/22/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-22
-pkgver=22.0.0_p0
+pkgver=22_p36
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -71,10 +71,10 @@ _jre() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="7077b9e42b40f1ed8d59a71ae59a57d5d55de2685cc5efd70a0405618da616d7"
+		_arch_sum="9b94b27229d21b74f9484b5963fd9517561a99a98f46c3f29c4b28c311e091a3"
 		;;
 	aarch64)
-		_arch_sum="e961c43fa418a74d5349d519d4f05b70f2017b13420812946be88349729c8ff3"
+		_arch_sum="eb3885be4b9f555d70d534dc1ac22d07bbd3a9246a6c56ad69897208c2d750cc"
 		;;
 esac
 

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jre
-Architecture: amd64 arm64 ppc64el s390x
+Architecture: amd64 arm64 ppc64el
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
@@ -11,7 +11,6 @@ arm64_checksum = 4748e5024eb0251ddf0f576e4c56d21270b1f2186f62b25fc1d89c888d742ed
 ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_ppc64le_linux_hotspot_22_36.tar.gz
 ppc64el_checksum = e1cce04600b388777a1a278dda572a664db14cea034dc131155b3da5e6e885e5
 
-
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm
 jvm_dir = $(pkg_name)-$(DEB_HOST_ARCH)

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
@@ -3,14 +3,14 @@
 pkg_name = temurin-22-jre
 priority = 2212
 jvm_tools = java jfr jrunscript jwebserver keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_x64_linux_hotspot_22.0.0_0.tar.gz
-amd64_checksum = 51141204fe01a9f9dd74eab621d5eca7511eac67315c9975dbde5f2625bdca55
-arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_aarch64_linux_hotspot_22.0.0_0.tar.gz
-arm64_checksum = 64c78854184c92a4da5cda571c8e357043bfaf03a03434eef58550cc3410d8a4
-ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.0_0.tar.gz
-ppc64el_checksum = caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22
-s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_s390x_linux_hotspot_22.0.0_0.tar.gz
-s390x_checksum = ff8191fa5b23a175932e7f4fab10a6e8df61fd71b6529c7d21451c81e82f8d55
+
+amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_x64_linux_hotspot_22_36.tar.gz
+amd64_checksum = faceda94ffd16e177cb674471f29789e48378f9f190eac8523713a0cb3324be9
+arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_aarch64_linux_hotspot_22_36.tar.gz
+arm64_checksum = 4748e5024eb0251ddf0f576e4c56d21270b1f2186f62b25fc1d89c888d742ed4
+TO_DO_ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.0_0.tar.gz
+TO_DO_ppc64el_checksum = caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22
+
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
@@ -8,8 +8,8 @@ amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/down
 amd64_checksum = faceda94ffd16e177cb674471f29789e48378f9f190eac8523713a0cb3324be9
 arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_aarch64_linux_hotspot_22_36.tar.gz
 arm64_checksum = 4748e5024eb0251ddf0f576e4c56d21270b1f2186f62b25fc1d89c888d742ed4
-TO_DO_ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.0_0.tar.gz
-TO_DO_ppc64el_checksum = caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22
+ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_ppc64le_linux_hotspot_22_36.tar.gz
+ppc64el_checksum = e1cce04600b388777a1a278dda572a664db14cea034dc131155b3da5e6e885e5
 
 
 d = debian/$(pkg_name)

--- a/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -3,8 +3,8 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
-#  22.0.0.0.0___1 == 22.0.0.0.0+35
-%global spec_version 22.0.0.0.0.0
+#  22.0.0.0.0___1 == 22.0.0.0.0+36
+%global spec_version 22.0.0.0.0.36
 %global spec_release 1
 %global priority 2200
 
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -28,7 +27,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -36,17 +34,8 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
-%endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global src_num 6
-%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -68,7 +57,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x
+ExclusiveArch: x86_64 ppc64le aarch64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -105,9 +94,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353
@@ -171,5 +157,5 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.0-0
+* Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -94,9 +94,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -3,8 +3,8 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
-#  22.0.0.0.0___1 == 22.0.0.0.0+35
-%global spec_version 22.0.0.0.0.0
+#  22.0.0.0.0___1 == 22.0.0.0.0+36
+%global spec_version 22.0.0.0.0.36
 %global spec_release 1
 %global priority 2200
 
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -28,7 +27,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -36,17 +34,8 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
 %global src_num 4
 %global sha_src_num 5
-%endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global src_num 6
-%global sha_src_num 7
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -68,7 +57,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x
+ExclusiveArch: x86_64 ppc64le aarch64
 
 BuildRequires:  tar
 BuildRequires:  wget


### PR DESCRIPTION
These files have s390x removed due to some blocking tests, this PR will allow publishing of all other linux installers. A 2nd PR to publish the s390x installers ( and an additional one to come will also be made, to include riscv support )