### PR TITLE
Correction to Windows ARM64 installer location

### DIFF
--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -10,7 +10,7 @@
     <?define Win64="yes" ?>
     <?define Arch="(x64)" ?>
   <?elseif $(env.Platform)=arm64?>
-    <?define ProgramFilesFolder="ProgramFilesARMFolder" ?>
+    <?define ProgramFilesFolder="ProgramFiles64Folder" ?>
     <?define Win64="no" ?>
     <?define Arch="(arm64)" ?>
   <?endif?>

--- a/wix/Main.wxs.template
+++ b/wix/Main.wxs.template
@@ -52,7 +52,7 @@
             </Directory>
          </Directory>
     <?elseif $(env.Platform)=arm64?>
-        <Directory Id="ProgramFilesARMFolder">
+        <Directory Id="ProgramFiles64Folder"> <!-- ARM64 is 64bit -->
             <Directory Id="PRODUCTMANUFACTURER" Name="$(var.ProductManufacturer)">
                 <Directory Id="INSTALLDIR" Name="$(var.AppFolder)" />
             </Directory>


### PR DESCRIPTION
The enumerator for the ARM64 TARGETDIR was set to ProgramFilesARMFolder, which doesn't seem to exist in Wix (3/4/5) any longer ([see here for details](https://wixtoolset.org/docs/v3/bundle/bundle_built_in_variables/))

Also, see [this document](https://learn.microsoft.com/en-us/windows/arm/faq#what-program-files-folder-should-i-use-to-install-my-arm64-application-) for a discussion on where applications for different architectures should be installed on Windows.

So, for the OpenJDK Windows installers, the following folders will be used:

- x86-32: `C:\Program Files (x86)\<vendor>\jdk-x`
- x64: `C:\Program Files\<vendor>\jdk-x`
- ARM64: `C:\Program Files\<vendor>\jdk-x`


Fixes #858 