### PR TITLE
Added ability to change output msi filename

### DIFF
--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -12,6 +12,7 @@ REM JVM=hotspot|openj9|dragonwell or both JVM=hotspot openj9
 REM PRODUCT_CATEGORY=jre|jdk (only one at a time)
 REM SKIP_MSI_VALIDATION=true (Add -sval option to light.exe to skip MSI/MSM validation and skip smoke.exe )
 REM UPGRADE_CODE_SEED=thisIsAPrivateSecretSeed ( optional ) for upgradable MSI (If none, new PRODUCT_UPGRADE_CODE is generate for each run)
+REM OUTPUT_BASE_FILENAME=customFileName (optional) for setting file names that are not based on the default naming convention
 
 SETLOCAL ENABLEEXTENSIONS
 SET ERR=0

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -148,7 +148,7 @@ FOR %%A IN (%ARCH%) DO (
     :CONTINUE
     ECHO Source dir used : !REPRO_DIR!
 
-    SET OUTPUT_BASE_FILENAME=!PRODUCT_SKU!!PRODUCT_MAJOR_VERSION!-!PRODUCT_CATEGORY!_!FOLDER_PLATFORM!_windows_!PACKAGE_TYPE!-!PRODUCT_FULL_VERSION!
+    IF NOT DEFINED OUTPUT_BASE_FILENAME SET OUTPUT_BASE_FILENAME=!PRODUCT_SKU!!PRODUCT_MAJOR_VERSION!-!PRODUCT_CATEGORY!_!FOLDER_PLATFORM!_windows_!PACKAGE_TYPE!-!PRODUCT_FULL_VERSION!
     REM find all *.wxi.template,*.wxl.template,*.wxs.template files and replace text with configurations
     FOR /f %%i IN ('dir /s /b *.wxi.template, *.Base.*.wxl.template *.!JVM!.*.wxl.template,*.wxs.template') DO (
         SET INPUT_FILE=%%~ni

--- a/wix/README.md
+++ b/wix/README.md
@@ -50,6 +50,8 @@ call powershell.exe ./CreateSourceFolder.AdoptOpenJDK.ps1 ^
   set VENDOR_BRANDING_LOGO=$(var.SetupResourcesDir)\logo.ico
   set VENDOR_BRANDING_BANNER=$(var.SetupResourcesDir)\wix-banner.png
   set VENDOR_BRANDING_DIALOG=$(var.SetupResourcesDir)\wix-dialog.png
+  set OUTPUT_BASE_FILENAME=%PRODUCT_SKU%%PRODUCT_MAJOR_VERSION%-%PRODUCT_CATEGORY%_%FOLDER_PLATFORM%_windows_%PACKAGE_TYPE%-%PRODUCT_F
+ULL_VERSION%
   ```
 
  `Build.OpenJDK_generic.cmd` statically depend on this SDK version (edit if needed):


### PR DESCRIPTION
Allows vendors to set custom filenames for MSIs and related files by setting the `OUTPUT_BASE_FILENAME` environment variable