### PR TITLE
Update Installer Files For JDK8, JDK11, JDK17, JDK21 & JDK22 for April CPU

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.22_p7
+pkgver=11.0.23_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-b541c99a5de71ebbe53e7815f9222e377b814fa1025f9f5274cb7bad226809f8  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+b45c467be52fe11ffd9bf69b3a035068134b305053874de4f3b3c5e5e1419659  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.10_p7
+pkgver=17.0.11_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-ce4085548f73ec97fa870de3f7da87634b4cbbf9753600365e2e0b255585e7e1  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+839326b5b4b3e4ac2edc3b685c8ab550f9b6d267eddf966323c801cb21e3e018  OpenJDK17U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/21/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/21/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-21
-pkgver=21.0.2_p13
+pkgver=21.0.3_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -97,10 +97,10 @@ _jdk() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="f1aef3652dd52778e81eb4897a88a34e38ca0159d22f160f7205e69907a0f14d"
+		_arch_sum="8e861638bf6b08c6d5837de6dc929930550928ec5fcc81b9fa7e8296afd0f9c0"
 		;;
 	aarch64)
-		_arch_sum="ae933ea8eeb4a077f19277842ba95ba93d29177e44d53cec7a98afd3b9abb2c3"
+		_arch_sum="0f68a9122054149861f6ce9d1b1c176bbe30dd76b36b74c916ba897c12e9d970"
 		;;
 esac
 

--- a/linux/jdk/alpine/src/main/packaging/temurin/22/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/22/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-22
-pkgver=22_p36
+pkgver=22.0.1_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -97,10 +97,10 @@ _jdk() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="f88fbe6360276cc9aec406802838ff0cfb368e08c2b1cf7b6fa78a846266a7af"
+		_arch_sum="d226e44b3513942db855df9a8737d848f64069848970d4cfd35ee3c38f2525c1"
 		;;
 	aarch64)
-		_arch_sum="e6c97db54afe145a8f93f9ca728b4df8a0490a45f0f999999c7464c64612e936"
+		_arch_sum="86a7b47c9277f2fd063ec910616b3676d86553ab7d23aa3bd365e51a57be1dc5"
 		;;
 esac
 

--- a/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jdk
-pkgver=8.402.06
+pkgver=8.412.08
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -67,6 +67,6 @@ package() {
 }
 
 sha256sums="
-c911fc057440f48c95f3eea8ec688732f43584e93fc0b090f5a361b2b6a64b71  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+409091665e5f8cf678938bbbc0d377122ef8bad7b1c97a0f809da054db956e51  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 "

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jdk (11.0.23.0.0+9) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.23.0.0+9 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-11-jdk (11.0.22.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.22.0.0+7release.
@@ -9,7 +15,7 @@ temurin-11-jdk (11.0.21.0.0+9) STABLE; urgency=medium
   * Eclipse Temurin 11.0.20.1.0+1release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 26 Oct 2023 08:00:00 +0000
- 
+
 temurin-11-jdk (11.0.20.1.0+1) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.20.1.0+1release.

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jdk
 priority = 1111
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200 jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.22_7.tar.gz
-amd64_checksum = 25cf602cac350ef36067560a4e8042919f3be973d419eac4d839e2e0000b2cc8
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.22_7.tar.gz
-arm64_checksum = ca1dc604352e9b3906b8955a700745a0a650ed59947f7f354af597871876a716
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jdk_arm_linux_hotspot_11.0.22_7.tar.gz
-armhf_checksum = 7d0e71d8aea6bba27dfbb9ad7434066896c3085327e58776ca89d5e262040bc5
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.22_7.tar.gz
-ppc64el_checksum = 95a1c215e434c302e43c8039f322b954ee539ca22412cd09b4dd77523aaa861a
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.22_7.tar.gz
-s390x_checksum = 137becfcfa6d288ba8c07ba23bf966c87bedfe7ee5cb3342da833407e13e3cfa
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.23_9.tar.gz
+amd64_checksum = 23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.23_9.tar.gz
+arm64_checksum = e00476a7be3c4adfa9b3d55d30768967fd246a8352e518894e183fa444d4d3ce
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.23_9.tar.gz
+armhf_checksum = 8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.23_9.tar.gz
+ppc64el_checksum = f56068bb64c6bf858894f75c2bc261f54db32932422eb07527f36ae40046e9a0
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.23_9.tar.gz
+s390x_checksum = cf06c3e41acfaeda77112ac04f5a711cafe9fa9ac04dff758696fe7e8d66a0ea
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jdk (17.0.11.0.0+9) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.11.0.0+9 release.
+
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 08:00:00 +0000
+
 temurin-17-jdk (17.0.10.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.10.0.0+7 release.
@@ -9,7 +15,7 @@ temurin-17-jdk (17.0.9.0.0+9) STABLE; urgency=medium
   * Eclipse Temurin 17.0.9.0.0+9 release.
 
   -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 26 Oct 2023 08:00:00 +0000
-  
+
 temurin-17-jdk (17.0.8.1.0+1) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.8.1.0+1 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jdk
 priority = 1711
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.10_7.tar.gz
-amd64_checksum = a8fd07e1e97352e97e330beb20f1c6b351ba064ca7878e974c7d68b8a5c1b378
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.10_7.tar.gz
-arm64_checksum = 6e4201abfb3b020c1fb899b7ac063083c271250bf081f3aa7e63d91291a90b74
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.10_7.tar.gz
-armhf_checksum = 9bb8ccb9993f85d07ca3d834354ce426857793262bea8dab861b0aebb152d89c
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.10_7.tar.gz
-ppc64el_checksum = f5fc5c9273b722ad73241a5e84feb4eba21697a57ba718dd16cfbddda45a6a4b
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.10_7.tar.gz
-s390x_checksum = 691f625edd425022500eea3b41ec6137fa078dab15632fda42de04f804079774
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz
+amd64_checksum = aa7fb6bb342319d227a838af5c363bfa1b4a670c209372f9e6585bd79da6220c
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.11_9.tar.gz
+arm64_checksum = a900acf3ae56b000afc35468a083b6d6fd695abec87a8abdb02743d5c72f6d6d
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_arm_linux_hotspot_17.0.11_9.tar.gz
+armhf_checksum = 9b5c375ed7ce654083c6c1137d8daadebaf8657650576115f0deafab00d0f1d7
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.11_9.tar.gz
+ppc64el_checksum = 44bdd662c3b832cfe0b808362866b8d7a700dd60e6e39716dee97211d35c230f
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.11_9.tar.gz
+s390x_checksum = af3f33c14ed3e2fcd85a390575029fbf92a491f60cfdc274544ac8ad6532de47
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,3 +1,9 @@
+temurin-21-jdk (21.0.3.0.0+9-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.3.0.0+9-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-21-jdk (21.0.2.0.0+13-2) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.2.0.0+13-2 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-21-jdk
 priority = 2111
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd jwebserver keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz
-amd64_checksum = 454bebb2c9fe48d981341461ffb6bf1017c7b7c6e15c6b0c29b959194ba3aaa5
-arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.2_13.tar.gz
-arm64_checksum = 3ce6a2b357e2ef45fd6b53d6587aa05bfec7771e7fb982f2c964f6b771b7526a
-ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.2_13.tar.gz
-ppc64el_checksum = d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f
-s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.2_13.tar.gz
-s390x_checksum = 0d5676c50821e0d0b951bf3ffd717e7a13be2a89d8848a5c13b4aedc6f982c78
-riscv64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.2_13.tar.gz
-riscv64_checksum = 791a37ddb040e1a02bbfc61abfbc7e7321431a28054c9ac59ba1738fd5320b02
+amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.3_9.tar.gz
+amd64_checksum = fffa52c22d797b715a962e6c8d11ec7d79b90dd819b5bc51d62137ea4b22a340
+arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.3_9.tar.gz
+arm64_checksum = 7d3ab0e8eba95bd682cfda8041c6cb6fa21e09d0d9131316fd7c96c78969de31
+ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.3_9.tar.gz
+ppc64el_checksum = 9a1079d7f0fc72951fdc9a0029e49a15f6ba114683aee626f882ee2c761f1d57
+s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.3_9.tar.gz
+s390x_checksum = f57a078d417614e5d78c07c77a6d8a04701058cf692c8e2868d593582be92768
+riscv64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.3_9.tar.gz
+riscv64_checksum = 246acb1db3ef69a7e3328fa378513b2e606e64710626ae8dd29decc0e525359b
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/changelog
@@ -1,3 +1,9 @@
+temurin-22-jdk (22.0.1.0.0+8-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 22.0.1.0.0+8-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-22-jdk (22.0.0.0.0+36) STABLE; urgency=medium
 
   * Eclipse Temurin 22.0.0.0.0+36 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jdk
-Architecture: amd64 arm64 ppc64el s390x riscv64
+Architecture: amd64 arm64 ppc64el riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
@@ -3,16 +3,14 @@
 pkg_name = temurin-22-jdk
 priority = 2211
 jvm_tools = jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jlink jmap jmod jpackage jps jrunscript jshell jstack jstat jstatd jwebserver keytool rmiregistry serialver jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_x64_linux_hotspot_22_36.tar.gz
-amd64_checksum = bc3d99e816d0c373f424cd7aa2b6d3e8081a7189fe55c1561616922200ec8e47
-arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_aarch64_linux_hotspot_22_36.tar.gz
-arm64_checksum = 4b52670caea44848cee893e35c804380817b6eff166cf64ee70ca2bfaac3d1c7
-ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_ppc64le_linux_hotspot_22_36.tar.gz
-ppc64el_checksum = 8c062e934d95c639f97b4e51b968eed694a6653248727c3db8bc5e0e55cfd7f4
-s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jdk_s390x_linux_hotspot_22_36.tar.gz
-s390x_checksum = fa77cfd9b79e98cc8078e42886098ac588e6adeda685771b98f32b9bdb8b5a57
-riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jdk_riscv64_linux_hotspot_22_36.tar.gz
-riscv64_checksum = a190d6afbf93587f6095b2b41cebc3ab3c05f7d7d07fde8bea8fbed14cbe7d6a
+amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_linux_hotspot_22.0.1_8.tar.gz
+amd64_checksum = e59c6bf801cc023a1ea78eceb5e6756277f1564cd0a421ea984efe6cb96cfcf8
+arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.1_8.tar.gz
+arm64_checksum = d8488fa1e4e8c1e318cef4c0fc3842a7f15a4cf52b27054663bb94471f54b3fa
+ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.1_8.tar.gz
+ppc64el_checksum = 4113606ba65044a3cbd7678e1c0d41881d24a2441c8ab8b658b4ac58da624de5
+riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_riscv64_linux_hotspot_22.0.1_8.tar.gz
+riscv64_checksum = 767bbe2b9581272b6ac435b8c62bb1c079041d6ff2a1c39552d4403b4d7170f5
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jdk (8.0.412.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.412.0.0+8 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, Apr 17 2024 00:00:00 +0000
+
 temurin-8-jdk (8.0.402.0.0+6) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.402.0.0+6 release.
@@ -13,7 +19,7 @@ temurin-8-jdk (8.0.382.0.0+5) STABLE; urgency=medium
   * Eclipse Temurin 8.0.382.0.0+5 release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, Jul 25 2023 11:59:00 +0000
- 
+
 temurin-8-jdk (8.0.372.0.0+7-1) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.372.0.0+7-1 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jdk
 priority = 1081
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = appletviewer clhsdb extcheck hsdb idlj jar jarsigner java javac javadoc javah javap jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc jexec
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u402b06.tar.gz
-amd64_checksum = fcfd08abe39f18e719e391f2fc37b8ac1053075426d10efac4cbf8969e7aa55e
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jdk_aarch64_linux_hotspot_8u402b06.tar.gz
-arm64_checksum = 241a72d6f0051de30c71e7ade95b34cd85a249c8e5925bcc7a95872bee81fd84
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jdk_arm_linux_hotspot_8u402b06.tar.gz
-armhf_checksum = 271f28c7b3592b201b7434292c21d923f520af8ff1c090b6849cb946e34a6bdb
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u402b06.tar.gz
-ppc64el_checksum = 64bc05cdffe827c84000177dca2eb4ff0a8ff0021889bb75abff3639d4f51838
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u412b08.tar.gz
+amd64_checksum = b9884a96f78543276a6399c3eb8c2fd8a80e6b432ea50e87d3d12d495d1d2808
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u412b08.tar.gz
+arm64_checksum = 3504d748a93f23cac8c060bd33231bd51e90dcb620f38dadc6239b6cd2a5011c
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_arm_linux_hotspot_8u412b08.tar.gz
+armhf_checksum = be4aff6fa7bf6515f16f93dcaf9fdc61853fe1ef0d25b08a1bb1cf6e3d047391
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u412b08.tar.gz
+ppc64el_checksum = 6b7ed7996788075e182dd33349288346240fbce540e50fd77aecfc309a5ada19
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.22+7
+%global upstream_version 11.0.23+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.22.0.0.7
+%global spec_version 11.0.23.0.0.9
 %global spec_release 1
 %global priority 1111
 
@@ -264,6 +264,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
+- Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1
 - Eclipse Temurin 11.0.21.0+9 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.21.0.0.1-9

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.10+7
+%global upstream_version 17.0.11+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.10.0.0.7
+%global spec_version 17.0.11.0.0.9
 %global spec_release 1
 %global priority 1161
 
@@ -261,6 +261,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.11.0.0.9-1
+- Eclipse Temurin 17.0.11+9 release.
 * Mon Jan 22 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.10.0.0.7-1
 - Eclipse Temurin 17.0.10+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.9.0.0.9-1

--- a/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 21.0.2+13
+%global upstream_version 21.0.3+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  21.0.0.0.0___1 == 21.0.0.0.0+35
-%global spec_version 21.0.2.0.0.13
-%global spec_release 2
+%global spec_version 21.0.3.0.0.9
+%global spec_release 1
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -253,6 +253,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.3.0.0.9-1
+- Eclipse Temurin 21.0.3+9 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1

--- a/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +28,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +36,14 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-# %ifarch s390x
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global vers_arch4 s390x
-# %global vers_arch5 riscv64
-# %global src_num 6
-# %global sha_src_num 7
-# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -129,9 +116,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22+36
+%global upstream_version 22.0.1+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.0.0.0.36
+%global spec_version 22.0.1.0.0.8
 %global spec_release 1
 %global priority 2200
 
@@ -13,7 +13,6 @@
 %global upstream_version_no_plus %(echo %{upstream_version} | sed 's/\+/_/g')
 %global java_provides openjdk
 
-
 # Map architecture to the expected value in the download URL; Allow for a
 # pre-defined value of vers_arch and use that if it's defined
 
@@ -21,7 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -30,7 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -39,25 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global vers_arch5 riscv64
-%global src_num 6
-%global sha_src_num 7
-%endif
+# %ifarch s390x
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global vers_arch4 s390x
+# %global vers_arch5 riscv64
+# %global src_num 6
+# %global sha_src_num 7
+# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -82,7 +81,8 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 riscv64
+# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -130,8 +130,8 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -253,5 +253,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
+- Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-ga-aarch32-20240419
+%global upstream_version 8u412-b08-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u402-b06
+%global upstream_version 8u412-b08
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.402.0.0.6
+%global spec_version 8.0.412.0.0.8
 %global spec_release 1
 %global priority 1081
 
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u402-b06-aarch32-20240118
+%global upstream_version jdk8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -278,6 +278,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
+- Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1
 - Eclipse Temurin 8.0.402-b06 release.
 * Wed Oct 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.392.0.0.8-1

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version jdk8u412-ga-aarch32-20240419
+%global upstream_version 8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.22+7
+%global upstream_version 11.0.23+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.22.0.0.7
+%global spec_version 11.0.23.0.0.9
 %global spec_release 1
 %global priority 1111
 
@@ -255,6 +255,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
+- Eclipse Temurin 11.0.23.0+9 release.
 * Mon Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1
 - Eclipse Temurin 11.0.22.0+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.21.0.0.1-9

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -1,9 +1,9 @@
-%global upstream_version 17.0.10+7
+%global upstream_version 17.0.11+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
-%global spec_version 17.0.10.0.0.7
+%global spec_version 17.0.11.0.0.9
 %global spec_release 1
 #  17.0.3.0.0___7 == 17.0.3.0.0+7
 %global priority 1161
@@ -251,6 +251,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.11.0.0.9-1
+- Eclipse Temurin 17.0.11+9 release.
 * Mon Jan 22 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.10.0.0.7-1
 - Eclipse Temurin 17.0.10+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.9.0.0.9-1

--- a/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/21/temurin-21-jdk.spec
@@ -1,11 +1,11 @@
-%global upstream_version 21.0.2+13
+%global upstream_version 21.0.3+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  21.0.0.0.0___1 == 21.0.0.0.0+35
-%global spec_version 21.0.2.0.0.13
-%global spec_release 2
+%global spec_version 21.0.3.0.0.9
+%global spec_release 1
 %global priority 1161
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -242,6 +242,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.3.0.0.9-1
+- Eclipse Temurin 21.0.3+9 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2
 - Eclipse Temurin 21.0.2+13 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-1

--- a/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +28,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +36,14 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-# %ifarch s390x
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global vers_arch4 s390x
-# %global vers_arch5 riscv64
-# %global src_num 6
-# %global sha_src_num 7
-# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -129,9 +116,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22+36
+%global upstream_version 22.0.1+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.0.0.0.36
+%global spec_version 22.0.1.0.0.8
 %global spec_release 1
 %global priority 2200
 
@@ -20,7 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global vers_arch5 riscv64
-%global src_num 6
-%global sha_src_num 7
-%endif
+# %ifarch s390x
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global vers_arch4 s390x
+# %global vers_arch5 riscv64
+# %global src_num 6
+# %global sha_src_num 7
+# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -81,7 +81,8 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 riscv64
+# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -129,8 +130,8 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_ar
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -242,5 +243,7 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
+- Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-ga-aarch32-20240419
+%global upstream_version 8u412-b08-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u402-b06
+%global upstream_version 8u412-b08
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.402.0.0.6
+%global spec_version 8.0.412.0.0.8
 %global spec_release 1
 %global priority 1081
 
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u402-b06-aarch32-20240118
+%global upstream_version jdk8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -268,6 +268,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
+- Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1
 - Eclipse Temurin 8.0.402-b06 release.
 * Wed Oct 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.392.0.0.8-1

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version jdk8u412-ga-aarch32-20240419
+%global upstream_version 8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.22_p7
+pkgver=11.0.23_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -72,5 +72,5 @@ _jre() {
 }
 
 sha256sums="
-cbadab09243a084c3dc8c7e546c0f17941758f9df9c22b227144ce4247ad94f3  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+6972a6251bc88d6fbb64a188557cf165f1c415ded550d2a280bbcbc4272caff1  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/17/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-17
-pkgver=17.0.10_p7
+pkgver=17.0.11_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -71,5 +71,5 @@ _jre() {
 }
 
 sha256sums="
-822f43f3de715b8eccad3fab8715cdfda02ec343f004fa56107e73433d2d6fa3  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+b5dffd0be08c464d9c3903e2947508c1a5c21804ea1cff5556991a2a47d617d8  OpenJDK17U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/alpine/src/main/packaging/temurin/21/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/21/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-21
-pkgver=21.0.2_p13
+pkgver=21.0.3_p9
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -71,10 +71,10 @@ _jre() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="7077b9e42b40f1ed8d59a71ae59a57d5d55de2685cc5efd70a0405618da616d7"
+		_arch_sum="b3e7170deab11a7089fe8e14f9f398424fd86db085f745dad212f6cfc4121df6"
 		;;
 	aarch64)
-		_arch_sum="e961c43fa418a74d5349d519d4f05b70f2017b13420812946be88349729c8ff3"
+		_arch_sum="54e8618da373258654fe788d509f087d3612de9e080eb6831601069dbc8a4b2b"
 		;;
 esac
 

--- a/linux/jre/alpine/src/main/packaging/temurin/22/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/22/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-22
-pkgver=22_p36
+pkgver=22.0.1_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -71,10 +71,10 @@ _jre() {
 
 case "$CARCH" in
 	x86_64)
-		_arch_sum="9b94b27229d21b74f9484b5963fd9517561a99a98f46c3f29c4b28c311e091a3"
+		_arch_sum="e7c26ad00e3ded356b8c4b20b184ccf5bd63ccdccabde8d4a892389f178f1d5b"
 		;;
 	aarch64)
-		_arch_sum="eb3885be4b9f555d70d534dc1ac22d07bbd3a9246a6c56ad69897208c2d750cc"
+		_arch_sum="6cac56dde6793d887deea101cfff283dc5f285e1118c21cbd1c4cb69f1072e55"
 		;;
 esac
 

--- a/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jre
-pkgver=8.402.06
+pkgver=8.412.08
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -60,5 +60,5 @@ ls ${srcdir}
 }
 
 sha256sums="
-abc7861abda181ffe4527997ef8267e701385f11b82d91bc3a56077be228b0e0  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+c82962d7378d1fd415db594fce6ec047939e9fab5301fa4407cd7faea9ea7e31  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,9 +1,15 @@
+temurin-11-jre (11.0.23.0.0+9) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.23.0.0+9 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-11-jre (11.0.22.0.0+7) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.22.0.0+7release.
 
  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Tue, 23 Jan 2024 08:00:00 +0000
- 
+
 temurin-11-jre (11.0.20.1.0+1) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.20.1.0+1 release.

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jre
 priority = 1112
 jvm_tools = jaotc java jfr jjs jrunscript keytool pack200 rmid rmiregistry unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.22_7.tar.gz
-amd64_checksum = 3a0fec1b9ef38d6abd86cf11f6001772b086096b6ec2588d2a02f1fa86b2b1de
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.22_7.tar.gz
-arm64_checksum = 46e2bff7d5f419ac7c2fad29e78bfacf49ead4a2de1aba73b6329128f6d1f707
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_arm_linux_hotspot_11.0.22_7.tar.gz
-armhf_checksum = a5ab40aa53ecd413a8af738e66855d423e64b5389f876a4825e2cbdb45e9cfb3
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.22_7.tar.gz
-ppc64el_checksum = a6719f71217d0b6f931461acec465ca3a1eb0b0e94942fe165e27b30ecc341c2
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7/OpenJDK11U-jre_s390x_linux_hotspot_11.0.22_7.tar.gz
-s390x_checksum = 1662e73deb814814fe27239666c5bf2d989484821343f0a3629ffb03729044ce
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.23_9.tar.gz
+amd64_checksum = 786a72296189ba8e43999532aa73730d87ec1fce558eb3c4e98b611b423375e3
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.23_9.tar.gz
+arm64_checksum = 7290ace47a030d89ea023c28e7aa555c9da72b4194f73b39ec9d058011bf06dd
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.23_9.tar.gz
+armhf_checksum = 025f994549708f7291ce3b0fa7c41f7e78ec3af3eae3f85fffe9c5fa4a54889f
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.23_9.tar.gz
+ppc64el_checksum = 3b3fbd324620fd914bd8462e292124493fcf846fd69195c4b9a231131dc68d5f
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.23_9.tar.gz
+s390x_checksum = 25abb7f74f55847b0d509402111084bd7a244d904744f3bfffa89528bc3b8a69
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,8 +1,8 @@
-temurin-17-jre (17.0.10.0.0+7) STABLE; urgency=medium
+temurin-17-jre (17.0.11.0.0+9) STABLE; urgency=medium
 
-  * Eclipse Temurin 17.0.10.0.0+7 release.
+  * Eclipse Temurin 17.0.11.0.0+9 release.
 
-  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Mon, 22 Jan 2024 08:00:00 +0000
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 08:00:00 +0000
 
 temurin-17-jre (17.0.9.0.0+9) STABLE; urgency=medium
 

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-17-jre
 priority = 1712
 jvm_tools = java jfr jrunscript keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.10_7.tar.gz
-amd64_checksum = 620cc0e7338f2722f3ed076ac65c0fafb575981426bac4e1970860e5e2d048f0
-arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.10_7.tar.gz
-arm64_checksum = 16080d055da0962fbd6b40f659a98a457cba3efa7ea716d5400cfebe8b935bf0
-armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_arm_linux_hotspot_17.0.10_7.tar.gz
-armhf_checksum = 0378bdf6769632b182b27ba4e53b17eaefefdbafa3845c15e1bd88a5aeec8442
-ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.10_7.tar.gz
-ppc64el_checksum = 4e18b60dba540b5c431ff03f74a1c73b22d83151f93b8768241d264d1a53582d
-s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_s390x_linux_hotspot_17.0.10_7.tar.gz
-s390x_checksum = c1b2fd232fc55e814479d7585d7ec45bae952a2f4137084f1d99f958c6880a49
+amd64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_linux_hotspot_17.0.11_9.tar.gz
+amd64_checksum = bcb1b7b8ad68c93093f09b591b7cb17161d39891f7d29d33a586f5a328603707
+arm64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.11_9.tar.gz
+arm64_checksum = ccfa23c25790475c84df983cc5f729b94c04d9ea9863912deb15c6266782cf16
+armhf_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_arm_linux_hotspot_17.0.11_9.tar.gz
+armhf_checksum = 2e06401aa3aa7a825d73a6af8e9462449b1a86e7705b793dc8ec90423b602ee2
+ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.11_9.tar.gz
+ppc64el_checksum = 884b5cb817e50010b4d0a3252afb6a80db18995af19bbd16a37348b2c37949bc
+s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_s390x_linux_hotspot_17.0.11_9.tar.gz
+s390x_checksum = 67dd46352ba94f273579a04ef0756408b06db82b1b4ddf050045c226212f76fd
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,3 +1,9 @@
+temurin-21-jre (21.0.3.0.0+9-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.3.0.0+9-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-21-jre (21.0.2.0.0+13-2) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.2.0.0+13-2 release.

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-21-jre
 priority = 2112
 jvm_tools = java jfr jrunscript jwebserver keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tar.gz
-amd64_checksum = 51141204fe01a9f9dd74eab621d5eca7511eac67315c9975dbde5f2625bdca55
-arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.2_13.tar.gz
-arm64_checksum = 64c78854184c92a4da5cda571c8e357043bfaf03a03434eef58550cc3410d8a4
-ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.2_13.tar.gz
-ppc64el_checksum = caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22
-s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_s390x_linux_hotspot_21.0.2_13.tar.gz
-s390x_checksum = ff8191fa5b23a175932e7f4fab10a6e8df61fd71b6529c7d21451c81e82f8d55
-riscv64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_riscv64_linux_hotspot_21.0.2_13.tar.gz
-riscv64_checksum = efdeca282553229aa20d909ab9f5fb14eee52b56067a5598e6c649ef5f99a63d
+amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_linux_hotspot_21.0.3_9.tar.gz.sig
+amd64_checksum = f1af100c4afca2035f446967323230150cfe5872b5a664d98c86963e5c066e0d
+arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.3_9.tar.gz
+arm64_checksum = c7c31bc6f5ab4c4b6f4559e11c2fa9541ae6757ab8da6dd85c29163913bd9238
+ppc64el_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.3_9.tar.gz
+ppc64el_checksum = aa628c6accc9d075b7b0f2bff6487f8ca0b8f057af31842a85fc8b363e1e10f3
+s390x_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_s390x_linux_hotspot_21.0.3_9.tar.gz
+s390x_checksum = a60dbad08a1977269dec7782f90225107479bfc8d10d2894f437778ae2e2b737
+riscv64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_riscv64_linux_hotspot_21.0.3_9.tar.gz
+riscv64_checksum = 83cae236bf823b6d6525a255f1e4ebd7bdb2e40e3778d1eb4d34b43478a680f9
 
 
 d = debian/$(pkg_name)

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/rules
@@ -3,7 +3,7 @@
 pkg_name = temurin-21-jre
 priority = 2112
 jvm_tools = java jfr jrunscript jwebserver keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_linux_hotspot_21.0.3_9.tar.gz.sig
+amd64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_linux_hotspot_21.0.3_9.tar.gz
 amd64_checksum = f1af100c4afca2035f446967323230150cfe5872b5a664d98c86963e5c066e0d
 arm64_tarball_url = https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.3_9.tar.gz
 arm64_checksum = c7c31bc6f5ab4c4b6f4559e11c2fa9541ae6757ab8da6dd85c29163913bd9238

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/changelog
@@ -1,3 +1,9 @@
+temurin-22-jre (22.0.1.0.0+8-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 22.0.1.0.0+8-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-22-jre (22.0.0.0.0+36-0) STABLE; urgency=medium
 
   * Eclipse Temurin 22.0.0.0.0+36-0 release.

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jre
-Architecture: amd64 arm64 ppc64el s390x riscv64
+Architecture: amd64 arm64 ppc64el riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
@@ -3,16 +3,14 @@
 pkg_name = temurin-22-jre
 priority = 2212
 jvm_tools = java jfr jrunscript jwebserver keytool rmiregistry
-amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_x64_linux_hotspot_22_36.tar.gz
-amd64_checksum = faceda94ffd16e177cb674471f29789e48378f9f190eac8523713a0cb3324be9
-arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_aarch64_linux_hotspot_22_36.tar.gz
-arm64_checksum = 4748e5024eb0251ddf0f576e4c56d21270b1f2186f62b25fc1d89c888d742ed4
-ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_ppc64le_linux_hotspot_22_36.tar.gz
-ppc64el_checksum = e1cce04600b388777a1a278dda572a664db14cea034dc131155b3da5e6e885e5
-s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.0%2B0/OpenJDK22U-jre_s390x_linux_hotspot_22_36.tar.gz
-s390x_checksum = d98725d8ea9971a361542b0243b08ff020e219489135ce8d01a8ae82972a81f3
-riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22%2B36/OpenJDK22U-jre_riscv64_linux_hotspot_22_36.tar.gz
-riscv64_checksum = a41a16ef998fa986fabe27588a435649eb7656a2235d546b5c8eb06938fb7a90
+amd64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_x64_linux_hotspot_22.0.1_8.tar.gz
+amd64_checksum = 154dbc7975cf765c59bdaa1e693d6c8b009635c9a182d6d6d9f0cfbec5317b4c
+arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_aarch64_linux_hotspot_22.0.1_8.tar.gz
+arm64_checksum = 8e5996a2bbae2da9797cff5a62cb2080965e08fd66de24673b29a8e481ec769e
+ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.1_8.tar.gz
+ppc64el_checksum = 7df4a10fab324181a6c9e8b1e2a45042b8d30490f0fdb937a536f6cd17c907ef
+riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_riscv64_linux_hotspot_22.0.1_8.tar.gz
+riscv64_checksum = 15193b64eac9a5ade9fc7d20fe90b9769887c0195afb20442d2a6adeb07c140f
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jre (8.0.412.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.412.0.0+8 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, Apr 17 2024 00:00:00 +0000
+
 temurin-8-jre (8.0.402.0.0+6) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.402.0.0+6 release.

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jre
 priority = 1082
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = java jjs keytool orbd pack200 policytool rmid rmiregistry servertool tnameserv unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jre_x64_linux_hotspot_8u402b06.tar.gz
-amd64_checksum = 1d8c109e96bdb35ffff667dfb911ce03fb9f0f924048dcc8fdbd45198b263ecd
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jre_aarch64_linux_hotspot_8u402b06.tar.gz
-arm64_checksum =782f842c22fe660c5acbea8c1d7b4e812fe658a9e48cd2e8e776d088c7ab32d3
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jre_arm_linux_hotspot_8u402b06.tar.gz
-armhf_checksum = d613a775573fc17ee972e62b5120dc34d8cac1810bb352e71bc01980ce3c48a8
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u402-b06/OpenJDK8U-jre_ppc64le_linux_hotspot_8u402b06.tar.gz
-ppc64el_checksum = dd828b761805c2caecac94fcab8ea39cdf41480f07053553dc37edde104861af
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz
+amd64_checksum = a8d994332a2ff15d48bf04405c3b2f6bd331a928dd96639b15e62891f7172363
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_aarch64_linux_hotspot_8u412b08.tar.gz
+arm64_checksum = 17550a6a4ddf71ac81ba8f276467bc58f036c123c0f1bafcafd69f70e3e49cf5
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_arm_linux_hotspot_8u412b08.tar.gz
+armhf_checksum = 1a6b470ac83b241223447a1e6cb55c4a8f78af0146b9387e9842625041226654
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u412b08.tar.gz
+ppc64el_checksum = d3157230c01b320e47ad6df650e83b15f8f76294d0df9f1c03867d07fe2883c9
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.22+7
+%global upstream_version 11.0.23+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.22.0.0.7
+%global spec_version 11.0.23.0.0.9
 %global spec_release 1
 %global priority 1112
 
@@ -199,6 +199,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
+- Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1
 - Eclipse Temurin 11.0.22.0+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.21.0.0.1-9

--- a/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.10+7
+%global upstream_version 17.0.11+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.10.0.0.7
+%global spec_version 17.0.11.0.0.9
 %global spec_release 1
 %global priority 1712
 
@@ -186,6 +186,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.11.0.0.9-1
+- Eclipse Temurin 17.0.11+9 release.
 * Mon Jan 22 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.10.0.0.7-1
 - Eclipse Temurin 17.0.10+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.9.0.0.9-1

--- a/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -1,11 +1,11 @@
-%global upstream_version 21.0.2+13
+%global upstream_version 21.0.3+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
-%global spec_version 21.0.2.0.0.13
-%global spec_release 3
+%global spec_version 21.0.3.0.0.9
+%global spec_release 1
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -187,6 +187,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.3.0.0.9-1
+- Eclipse Temurin 21.0.3+9 release.
 * Wed Feb 28 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-3
 - Eclipse Temurin 21.0.2+13 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2

--- a/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +28,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +36,14 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-# %ifarch s390x
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global vers_arch4 s390x
-# %global vers_arch5 riscv64
-# %global src_num 6
-# %global sha_src_num 7
-# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -119,9 +106,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22+36
+%global upstream_version 22.0.1+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.0.0.0.36
+%global spec_version 22.0.1.0.0.8
 %global spec_release 1
 %global priority 2200
 
@@ -20,7 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global vers_arch5 riscv64
-%global src_num 6
-%global sha_src_num 7
-%endif
+# %ifarch s390x
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global vers_arch4 s390x
+# %global vers_arch5 riscv64
+# %global src_num 6
+# %global sha_src_num 7
+# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -81,7 +81,8 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 riscv64
+# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -119,8 +120,8 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -187,5 +188,7 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
+- Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-ga-aarch32-20240419
+%global upstream_version 8u412-b08-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version jdk8u412-ga-aarch32-20240419
+%global upstream_version 8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -192,7 +192,6 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
-%changelog
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
 - Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u402-b06
+%global upstream_version 8u412-b08
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.402.0.0.6
+%global spec_version 8.0.412.0.0.8
 %global spec_release 1
 %global priority 1082
 
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u402-b06-aarch32-20240118
+%global upstream_version jdk8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -193,6 +193,8 @@ fi
 
 %changelog
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
+- Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1
 - Eclipse Temurin 8.0.402-b06 release.
 * Wed Oct 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.392.0.0.8-1

--- a/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.22+7
+%global upstream_version 11.0.23+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.22.0.0.7
+%global spec_version 11.0.23.0.0.9
 %global spec_release 1
 %global priority 1112
 
@@ -190,6 +190,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
+- Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1
 - Eclipse Temurin 11.0.22.0+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.21.0.0.1-9

--- a/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 17.0.10+7
+%global upstream_version 17.0.11+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 17.0.1.0.1___17.0.1.0+12
 #  17.0.1.0.0___12 == 17.0.1.0.0+12
-%global spec_version 17.0.10.0.0.7
+%global spec_version 17.0.11.0.0.9
 %global spec_release 1
 %global priority 1712
 
@@ -176,6 +176,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.11.0.0.9-1
+- Eclipse Temurin 17.0.11+9 release.
 * Mon Jan 22 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.10.0.0.7-1
 - Eclipse Temurin 17.0.10+7 release.
 * Thu Oct 26 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 17.0.9.0.0.9-1

--- a/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/21/temurin-21-jre.spec
@@ -1,11 +1,11 @@
-%global upstream_version 21.0.2+13
+%global upstream_version 21.0.3+9
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 21.0.0.0.0___21.0.0.0.0+1
 #  20.0.0.0.0___1 == 21.0.0.0.0+35
-%global spec_version 21.0.2.0.0.13
-%global spec_release 3
+%global spec_version 21.0.3.0.0.9
+%global spec_release 1
 %global priority 2100
 
 %global source_url_base https://github.com/adoptium/temurin21-binaries/releases/download
@@ -177,6 +177,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.3.0.0.9-1
+- Eclipse Temurin 21.0.3+9 release.
 * Wed Feb 28 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-3
 - Eclipse Temurin 21.0.2+13 release.
 * Wed Feb 21 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 21.0.2.0.0.13-2

--- a/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -20,7 +20,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +28,6 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +36,14 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-# %ifarch s390x
-# %global vers_arch x64
-# %global vers_arch2 ppc64le
-# %global vers_arch3 aarch64
-# %global vers_arch4 s390x
-# %global vers_arch5 riscv64
-# %global src_num 6
-# %global sha_src_num 7
-# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -119,9 +106,6 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 # Third architecture (aarch64)
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Fourth architecture (s390x)
-# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt

--- a/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22+36
+%global upstream_version 22.0.1+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.0.0.0.36
+%global spec_version 22.0.1.0.0.8
 %global spec_release 1
 %global priority 2200
 
@@ -20,7 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -29,7 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -38,25 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
-%ifarch s390x
-%global vers_arch x64
-%global vers_arch2 ppc64le
-%global vers_arch3 aarch64
-%global vers_arch4 s390x
-%global vers_arch5 riscv64
-%global src_num 6
-%global sha_src_num 7
-%endif
+# %ifarch s390x
+# %global vers_arch x64
+# %global vers_arch2 ppc64le
+# %global vers_arch3 aarch64
+# %global vers_arch4 s390x
+# %global vers_arch5 riscv64
+# %global src_num 6
+# %global sha_src_num 7
+# %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
-%global vers_arch4 s390x
+# %global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -81,7 +81,8 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 riscv64
+# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -119,8 +120,8 @@ Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_ar
 Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fourth architecture (s390x)
-Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+# Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -177,5 +178,7 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
+- Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 30 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0
 - Eclipse Temurin 22+36 release 0.

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-ga-aarch32-20240419
+%global upstream_version 8u412-b08-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u402-b06
+%global upstream_version 8u412-b08
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.402.0.0.6
+%global spec_version 8.0.412.0.0.8
 %global spec_release 1
 %global priority 1082
 
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u402-b06-aarch32-20240118
+%global upstream_version jdk8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -182,6 +182,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
+- Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1
 - Eclipse Temurin 8.0.402-b06 release.
 * Wed Oct 25 2023 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.392.0.0.8-1

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version jdk8u412-ga-aarch32-20240419
+%global upstream_version 8u412-ga-aarch32-20240419
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch


### PR DESCRIPTION
This PR updates the installer files, so that installers for the April CPU can be published.

Note that for JDK22, s390x code has been removed, as this will require a follow up change to allow for the bump in version number for the s390x specific JDK patch.