### PR TITLE
linux: run tests on all files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,20 +26,17 @@ jobs:
     # Map a step output to a job output
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
-      cacerts: ${{ steps.changes.outputs.cacerts }}
+      cacerts: ${{ steps.cacerts.outputs.cacerts }}
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-
-      - name: Get changed files
-        id: changes
+  
+      - name: Check if cacerts changed
+        id: cacerts
         # Set outputs using the command.
         run: |
-          changed_files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)
-          echo $changed_files
-          echo "all=$changed_files" >> $GITHUB_OUTPUT
           cacerts=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep ca-certificates | xargs)
           echo "cacerts=$cacerts" >> $GITHUB_OUTPUT
 
@@ -50,23 +47,13 @@ jobs:
           # Loop through the changed files and generate a matrix of jobs to run
           # The matrix is a JSON string that is used in the next step
 
-          # Set test versions if version cannot be determined from the path
-          versions_to_test=(
-            "8"
-            "11"
-            "17"
-            "20"
-          )
+          all_files=$(git ls-files linux)
 
-          # If this job is being run on a pull request, only run the matrix for the changed files
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            changed_files="${{ steps.changes.outputs.all }}"
-          else
-            changed_files=$(git ls-files linux)
-          fi
+          # Add versions here to be skipped from CI once they've reached EOL
+          skipped_versions='["19","20"]'
 
           matrix='['
-          for file in $(echo ${changed_files} | tr " " "\n")
+          for file in $(echo ${all_files} | tr " " "\n")
           do
             # capitalize distro unless it's redhat (set as RedHat)
             capitalize () {
@@ -92,16 +79,12 @@ jobs:
                   continue
                 fi
                 version=$(echo $file | cut -d'/' -f 8)
-                # test if version is a number and otherwise use versions_to_test
-                if ! [[ $version =~ ^[0-9]+$ ]]; then
-                  name="temurin"
-                  for version in "${versions_to_test[@]}"
-                  do
-                    matrix+='{"image_type":"'"$type"'","distro":"'"$distro"'","product":{"name":"'"$name"'","version":"'"$version"'"}},'
-                  done
-                else
-                  matrix+='{"image_type":"'"$type"'","distro":"'"$distro"'","product":{"name":"'"$name"'","version":"'"$version"'"}},'
+                # if version in skipped_versions skip
+                if [[ $skipped_versions == *"$version"* ]]; then
+                  continue
                 fi
+
+                matrix+='{"image_type":"'"$type"'","distro":"'"$distro"'","product":{"name":"'"$name"'","version":"'"$version"'"}},'
               ;;
             esac
           done
@@ -110,8 +93,8 @@ jobs:
           matrix+=']'
           # check if matrix is empty
           if [[ $matrix == ']' ]]; then
-            echo "No jobs to run"
-            matrix='[]'
+            echo "error: No matrix generated"
+            exit 1
           else
             # remove any duplicate entries
             matrix=$(echo $matrix | jq -S 'unique')
@@ -133,10 +116,9 @@ jobs:
 
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: '17'
+          java-version: 17
           java-package: jdk
-          architecture: x64
-          distribution: 'temurin'
+          distribution: temurin
 
       - name: Build
         run: |
@@ -146,7 +128,7 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always() # always run even if the previous step fails
         with:
-          name: test-results
+          name: test-results-ca-certificates
           path: '**/build/test-results/**/TEST-*.xml'
 
   check-packages:
@@ -168,10 +150,9 @@ jobs:
 
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
-          java-version: '17'
+          java-version: 17
           java-package: jdk
-          architecture: x64
-          distribution: 'temurin'
+          distribution: temurin
 
       - name: Build # only simulate in Jenkins when select ARCH="all"
         run: |
@@ -188,6 +169,26 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always() # always run even if the previous step fails
         with:
+          name: test-results-${{ matrix.product.name }}-${{ matrix.product.version }}-${{ matrix.distro }}-${{ matrix.image_type }}
+          path: '**/build/test-results/**/TEST-*.xml'
+
+  merge-results:
+    name: Merge Test Results
+    needs: check-packages
+    if: github.event_name == 'pull_request' || github.repository_owner != 'adoptium'
+    runs-on: ubuntu-latest
+    steps:  
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: test-results-*
+          merge-multiple: true
+      
+      - uses: geekyeggo/delete-artifact@24928e75e6e6590170563b8ddae9fac674508aa1 # v5.0.0
+        with:
+          name: test-results-*
+
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
           name: test-results
           path: '**/build/test-results/**/TEST-*.xml'
 
@@ -198,4 +199,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: gradle/wrapper-validation-action@216d1ad2b3710bf005dc39237337b9673fd8fcd5 # v3.3.2
+      - uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-  
+
       - name: Check if cacerts changed
         id: cacerts
         # Set outputs using the command.

--- a/.github/workflows/linuxTriage.yml
+++ b/.github/workflows/linuxTriage.yml
@@ -6,6 +6,10 @@ on:
       - completed
 jobs:
   report:
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@c40d89d5e987cd80f3a32b3c233556e22bdca958 # v1.9.0


### PR DESCRIPTION
We've been missing certain issues with dependency upgrades that aren't being tested correctly with the automatic matrix generator. This PR switches it to just run all build/tests which we can comfortably do now we have more GH actions minutes.

Also applies a fix to resolve the breaking changes in v4 upload/download artifacts