### PR TITLE
April CPU - Change Spec Files etc to ship JDK22 s390x Patched Packages

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/changelog
@@ -1,3 +1,9 @@
+temurin-22-jdk (22.0.1.1.0+1-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 22.0.1.1.0+1-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-22-jdk (22.0.1.0.0+8-1) STABLE; urgency=medium
 
   * Eclipse Temurin 22.0.1.0.0+8-1 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jdk
-Architecture: amd64 arm64 ppc64el riscv64
+Architecture: amd64 arm64 ppc64el s390x riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/22/debian/rules
@@ -9,6 +9,8 @@ arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/down
 arm64_checksum = d8488fa1e4e8c1e318cef4c0fc3842a7f15a4cf52b27054663bb94471f54b3fa
 ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.1_8.tar.gz
 ppc64el_checksum = 4113606ba65044a3cbd7678e1c0d41881d24a2441c8ab8b658b4ac58da624de5
+s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1.1%2B1/OpenJDK22U-jdk_s390x_linux_hotspot_22.0.1.1_1.tar.gz
+s390x_checksum = 9f648abfa8ae82a1138bf069f498bc73d5ed0463b3f5d79e5d0988d28f9ffcc5
 riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_riscv64_linux_hotspot_22.0.1_8.tar.gz
 riscv64_checksum = 767bbe2b9581272b6ac435b8c62bb1c079041d6ff2a1c39552d4403b4d7170f5
 

--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -39,7 +39,7 @@ fi
 
 # loop spec file originally from src/main/packaging/$product/$productVersion/*.spec
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
-	spectool -g -R "$spec";
+	spectool -g -R -f "$spec";
 	rpmbuild --define "local_build ${buildLocalFlag}" \
 				--nodeps -bs "$spec"; # build src.rpm
 	# if buildArch == all, extract ExclusiveArch from the spec file
@@ -50,6 +50,7 @@ for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 		ExclusiveArch=$(grep -E "^ExclusiveArch:" "$spec" | sed -e 's/ExclusiveArch: *//' | sed -e 's/%{arm}/armv7hl/g')
 		[ -n "$ExclusiveArch" ] && targets="${ExclusiveArch}"
 	fi
+	targets="s390x"
 	for target in $targets; do
 		rpmbuild --target "$target" \
 					--define "local_build ${buildLocalFlag}" \

--- a/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22.0.1+8
+%global upstream_version 22.0.1.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.1.0.0.8
+%global spec_version 22.0.1.1.0.1
 %global spec_release 1
 %global priority 2200
 
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -28,6 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -36,14 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global vers_arch5 riscv64
+%global src_num 6
+%global sha_src_num 7
 %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -68,8 +81,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 riscv64
-# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -108,17 +120,20 @@ Provides: java-sdk-22-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
-# Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Second architecture (ppc64le)%global vers_arch4 s390x
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
-Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353
@@ -237,6 +252,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.1.0.1-1
+- Eclipse Temurin 22.0.1.1+1 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
 - Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0

--- a/linux/jdk/suse/src/main/packaging/build.sh
+++ b/linux/jdk/suse/src/main/packaging/build.sh
@@ -15,7 +15,7 @@ else
 fi
 
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
-	rpmdev-spectool -g -R "$spec";
+	rpmdev-spectool -g -R -f "$spec";
 	rpmbuild --nodeps -bs "$spec";
 	# if buildArch == all, extract ExclusiveArch from the spec file
 	if [ "${buildArch}" = "all" ]; then
@@ -25,6 +25,7 @@ for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 		ExclusiveArch=$(grep -E "^ExclusiveArch:" "$spec" | sed -e 's/ExclusiveArch: *//' | sed -e 's/%{arm}/armv7hl/g')
 		[ -n "$ExclusiveArch" ] && targets="${ExclusiveArch}"
 	fi
+	targets="s390x"
 	for target in $targets; do
 		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
 	done;

--- a/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/22/temurin-22-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22.0.1+8
+%global upstream_version 22.0.1.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.1.0.0.8
+%global spec_version 22.0.1.1.0.1
 %global spec_release 1
 %global priority 2200
 
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -28,6 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -36,14 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global vers_arch5 riscv64
+%global src_num 6
+%global sha_src_num 7
 %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -68,8 +81,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 riscv64
-# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -108,17 +120,20 @@ Provides: java-sdk-22-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
-Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jdk_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}
@@ -227,6 +242,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.1.0.1-1
+- Eclipse Temurin 22.0.1.1+1 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
 - Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/changelog
@@ -1,3 +1,9 @@
+temurin-22-jre (22.0.1.1.0+1-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 22.0.1.1.0+1-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Apr 2024 00:00:00 +0000
+
 temurin-22-jre (22.0.1.0.0+8-1) STABLE; urgency=medium
 
   * Eclipse Temurin 22.0.1.0.0+8-1 release.

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/control
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-22-jre
-Architecture: amd64 arm64 ppc64el riscv64
+Architecture: amd64 arm64 ppc64el s390x riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/22/debian/rules
@@ -9,6 +9,8 @@ arm64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/down
 arm64_checksum = 8e5996a2bbae2da9797cff5a62cb2080965e08fd66de24673b29a8e481ec769e
 ppc64el_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.1_8.tar.gz
 ppc64el_checksum = 7df4a10fab324181a6c9e8b1e2a45042b8d30490f0fdb937a536f6cd17c907ef
+s390x_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1.1%2B1/OpenJDK22U-jre_s390x_linux_hotspot_22.0.1.1_1.tar.gz
+s390x_checksum = 86dd7d37d5bb6091f3e6e2da4049ffaa0c5c2576cfcb45659606c4aab83b5824
 riscv64_tarball_url = https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_riscv64_linux_hotspot_22.0.1_8.tar.gz
 riscv64_checksum = 15193b64eac9a5ade9fc7d20fe90b9769887c0195afb20442d2a6adeb07c140f
 

--- a/linux/jre/redhat/src/main/packaging/build.sh
+++ b/linux/jre/redhat/src/main/packaging/build.sh
@@ -39,7 +39,7 @@ fi
 
 # loop spec file originally from src/main/packaging/$product/$productVersion/*.spec
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
-	spectool -g -R "$spec";
+	spectool -g -R -f "$spec";
 	rpmbuild --define "local_build ${buildLocalFlag}" \
 				--nodeps -bs "$spec"; # build src.rpm
 	# if buildArch == all, extract ExclusiveArch from the spec file
@@ -50,6 +50,7 @@ for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 		ExclusiveArch=$(grep -E "^ExclusiveArch:" "$spec" | sed -e 's/ExclusiveArch: *//' | sed -e 's/%{arm}/armv7hl/g')
 		[ -n "$ExclusiveArch" ] && targets="${ExclusiveArch}"
 	fi
+	targets="s390x"
 	for target in $targets; do
 		rpmbuild --target "$target" \
 					--define "local_build ${buildLocalFlag}" \

--- a/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -28,6 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -36,6 +38,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
@@ -44,6 +47,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 6
 %global sha_src_num 7
@@ -52,6 +56,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9

--- a/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22.0.1+8
+%global upstream_version 22.0.1.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.1.0.0.8
+%global spec_version 22.0.1.1.0.1
 %global spec_release 1
 %global priority 2200
 
@@ -40,6 +40,14 @@
 %global src_num 4
 %global sha_src_num 5
 %endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch5 riscv64
+%global src_num 6
+%global sha_src_num 7
+%endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
@@ -68,8 +76,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 riscv64
-# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -98,17 +105,20 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
-Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353
@@ -172,6 +182,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.1.0.1-1
+- Eclipse Temurin 22.0.1.1+1 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
 - Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 20 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0

--- a/linux/jre/suse/src/main/packaging/build.sh
+++ b/linux/jre/suse/src/main/packaging/build.sh
@@ -15,7 +15,7 @@ else
 fi
 
 for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
-	rpmdev-spectool -g -R "$spec";
+	rpmdev-spectool -g -R -f "$spec";
 	rpmbuild --nodeps -bs "$spec";
 	# if buildArch == all, extract ExclusiveArch from the spec file
 	if [ "${buildArch}" = "all" ]; then
@@ -25,6 +25,7 @@ for spec in "$(ls /home/builder/build/generated/packaging/*.spec)"; do
 		ExclusiveArch=$(grep -E "^ExclusiveArch:" "$spec" | sed -e 's/ExclusiveArch: *//' | sed -e 's/%{arm}/armv7hl/g')
 		[ -n "$ExclusiveArch" ] && targets="${ExclusiveArch}"
 	fi
+	targets="s390x"
 	for target in $targets; do
 		rpmbuild --target "$target" --rebuild /home/builder/rpmbuild/SRPMS/*.src.rpm;
 	done;

--- a/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/22/temurin-22-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 22.0.1+8
+%global upstream_version 22.0.1.1+1
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 22.0.0.0.0___22.0.0.0.0+1
 #  22.0.0.0.0___1 == 22.0.0.0.0+36
-%global spec_version 22.0.1.0.0.8
+%global spec_version 22.0.1.1.0.1
 %global spec_release 1
 %global priority 2200
 
@@ -20,6 +20,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 0
 %global sha_src_num 1
@@ -28,6 +29,7 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 2
 %global sha_src_num 3
@@ -36,14 +38,25 @@
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 4
 %global sha_src_num 5
+%endif
+%ifarch s390x
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 aarch64
+%global vers_arch4 s390x
+%global vers_arch5 riscv64
+%global src_num 6
+%global sha_src_num 7
 %endif
 %ifarch riscv64
 %global vers_arch x64
 %global vers_arch2 ppc64le
 %global vers_arch3 aarch64
+%global vers_arch4 s390x
 %global vers_arch5 riscv64
 %global src_num 8
 %global sha_src_num 9
@@ -68,8 +81,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le aarch64 riscv64
-# ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
+ExclusiveArch: x86_64 ppc64le aarch64 s390x riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -98,17 +110,20 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # First architecture (x86_64)
-Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Second architecture (ppc64le)
-Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch2}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source2: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source3: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Third architecture (aarch64)
-Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch3}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source4: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source5: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Fourth architecture (s390x)
+Source6: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 # Fifth architecture (riscv64)
-Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
-Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK22U-jre_%{vers_arch4}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}
@@ -162,6 +177,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.1.0.1-1
+- Eclipse Temurin 22.0.1.1+1 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.1.0.0.8-1
 - Eclipse Temurin 22.0.1+8 release.
 * Wed Mar 30 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 22.0.0.0.0.36-0


### PR DESCRIPTION
Due to the nature of our RPM spec files, I recommend this PR not be merged, Im only opening it to allow the packages to be published..

The debian changes are all ok, and as standard, but due to the implementation methods in the rpm spec files and build script, I recommend this PR not be merged, and will simply be closed to serve as a reminder detailing how this had to be achieved, where only a single architecture receives a patch.