### PR TITLE
Fix alpine/aarch64 apk files (which are currently x64)

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -336,8 +336,8 @@ def jenkinsStepAlpine() {
         // special handle: no label x86_64 only x64 for alpine agent
         def apkLabel = "${ApkARCH}&&docker"
 
+        if ("${ApkARCH}" == 'x86_64') {
             apkLabel = 'x64&&dockerBuild'
-            if ("${ApkARCH}" == 'x86_64') {
         }
         // reallocate jenkins agent per element in list
         if (ApkARCH == 'x86_64' || ApkARCH == 'aarch64') {


### PR DESCRIPTION
Reverts a change that looks to have been accidentally introduced as part of https://github.com/adoptium/installer/pull/847

Fixes https://github.com/adoptium/installer/issues/892 (once rebuilt appropriately)