### PR TITLE
Update Spec Files For JDK17 RiscV Release

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -9,7 +9,7 @@ aarch64     aarch64     arm64       arm64
 ppc64le     ppc64le     ppc64le
 source      src         -           only for SRPM and no need specify as option or target
 s390x       s390x       s390x       only for jdk8+
-riscv64     riscv64     riscv64     only for JDK21+
+riscv64     riscv64     riscv64     only for JDK17+
 */
 
 env.NODE_LABEL = 'dockerBuild&&linux&&x64' // Default node and also used for build RedHat + Suse + Debian x64
@@ -271,10 +271,6 @@ def jenkinsStepDeb() {
     if ("${VERSION}" == '11' && "${ARCH}" == 'all') {
         debArchAllList = ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x']
     }
-    // remove riscv64 for JDK17
-    if ("${VERSION}" == '17' && "${ARCH}" == 'all') {
-        debArchAllList = ['x86_64', 'armv7l', 'aarch64', 'ppc64le', 's390x']
-    }
     // remove Arm32 & add riscv64 for JDK21
     if ("${VERSION}" == '21' && "${ARCH}" == 'all' ) {
         debArchAllList = ['x86_64', 'aarch64', 'ppc64le', 's390x', 'riscv64']
@@ -409,9 +405,6 @@ def buildAndTest(String DISTRO, String buildArch, String VERSION) {
                 debArchList.remove('s390x')
                 break
               case "11":
-                debArchList.remove('riscv64')
-                break
-              case "17":
                 debArchList.remove('riscv64')
                 break
               case "21":
@@ -608,6 +601,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch, String Version) {
 
     if (VERSION == '17') {
     rpmArchList['s390x'] = 's390x'
+    rpmArchList['riscv64'] = 'riscv64'
   }
   if (VERSION == '21') {
     rpmArchList['s390x'] = 's390x'

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/control
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-17-jdk
-Architecture: amd64 armhf arm64 ppc64el s390x
+Architecture: amd64 armhf arm64 ppc64el s390x riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/rules
@@ -13,6 +13,8 @@ ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/do
 ppc64el_checksum = 44bdd662c3b832cfe0b808362866b8d7a700dd60e6e39716dee97211d35c230f
 s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.11_9.tar.gz
 s390x_checksum = af3f33c14ed3e2fcd85a390575029fbf92a491f60cfdc274544ac8ad6532de47
+riscv64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_riscv64_linux_hotspot_17.0.11_9.tar.gz
+riscv64_checksum = f54c301e3ed3250b3f11cb06eeb799e4aa871477b1ce8bf9fec9fee8ce6beb96
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/Dockerfile
+++ b/linux/jdk/redhat/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:38
 
 RUN dnf update -y && dnf install -y rpmdevtools \
 	rpm-sign \

--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -31,6 +31,8 @@ echo "DEBUG: building RH arch ${buildArch} with jdk version ${buildVersion}"
 # Build specified target or build all
 if [ "${buildArch}" != "all" ]; then
 	targets=${buildArch}
+elif [ ${buildVersion} -eq 17 ]; then
+        targets="x86_64 ppc64le aarch64 armv7hl s390x riscv64"
 elif [ ${buildVersion} -gt 20 ]; then
         targets="x86_64 ppc64le aarch64 s390x riscv64"
 else

--- a/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -22,6 +22,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -31,6 +32,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -40,6 +42,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
@@ -49,6 +52,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 6
 %global sha_src_num 7
 %endif
@@ -58,8 +62,19 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 8
 %global sha_src_num 9
+%endif
+%ifarch %{riscv64}
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global vers_arch4 aarch64
+%global vers_arch5 arm
+%global vers_arch6 riscv64
+%global src_num 10
+%global sha_src_num 11
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -81,7 +96,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm}
+ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm} riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -142,6 +157,9 @@ Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_ar
 # Fifth architecture (arm32)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Sixth architecture (riscv64)
+Source10: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source11: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/17/temurin-17-jdk.spec
@@ -22,6 +22,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -31,6 +32,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -40,6 +42,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
@@ -49,6 +52,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 6
 %global sha_src_num 7
 %endif
@@ -58,8 +62,19 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 8
 %global sha_src_num 9
+%endif
+%ifarch riscv64
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global vers_arch4 aarch64
+%global vers_arch5 arm
+%global vers_arch6 riscv64
+%global src_num 10
+%global sha_src_num 11
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -81,7 +96,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm}
+ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm} riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -142,6 +157,9 @@ Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_ar
 # Fifth architecture (arm32)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Sixth architecture (riscv64)
+Source10: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source11: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/control
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/control
@@ -5,7 +5,7 @@ Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 Build-Depends: debhelper (>= 11), lsb-release
 
 Package: temurin-17-jre
-Architecture: amd64 armhf arm64 ppc64el s390x
+Architecture: amd64 armhf arm64 ppc64el s390x riscv64
 Depends: adoptium-ca-certificates,
          java-common,
          libasound2,

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
@@ -13,6 +13,8 @@ ppc64el_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/do
 ppc64el_checksum = 884b5cb817e50010b4d0a3252afb6a80db18995af19bbd16a37348b2c37949bc
 s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_s390x_linux_hotspot_17.0.11_9.tar.gz
 s390x_checksum = 67dd46352ba94f273579a04ef0756408b06db82b1b4ddf050045c226212f76fd
+riscv64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_riscv64_linux_hotspot_17.0.11_9.tar.gz
+riscv64_checksum = e814bfe176ee1d1dc8054571070a0f98fc6a87477382d84df7c6bed27622f97e
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/Dockerfile
+++ b/linux/jre/redhat/src/main/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:38
 
 RUN dnf update -y && dnf install -y rpmdevtools \
 	rpm-sign \

--- a/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -22,6 +22,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -31,6 +32,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -40,6 +42,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
@@ -49,6 +52,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 6
 %global sha_src_num 7
 %endif
@@ -58,8 +62,19 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 8
 %global sha_src_num 9
+%endif
+%ifarch riscv64
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global vers_arch4 aarch64
+%global vers_arch5 arm
+%global vers_arch6 riscv64
+%global src_num 10
+%global sha_src_num 11
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -81,7 +96,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: /usr/lib/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm}
+ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm} riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -124,6 +139,9 @@ Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_ar
 # Fifth architecture (arm32)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Sixth architecture (riscv64)
+Source10: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source11: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Set the compression format to xz to be compatible with more Red Hat flavours. Newer versions of Fedora use zstd which
 # is not available on CentOS 7, for example. https://github.com/rpm-software-management/rpm/blob/master/macros.in#L353

--- a/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/17/temurin-17-jre.spec
@@ -22,6 +22,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 0
 %global sha_src_num 1
 %endif
@@ -31,6 +32,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 2
 %global sha_src_num 3
 %endif
@@ -40,6 +42,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 4
 %global sha_src_num 5
 %endif
@@ -49,6 +52,7 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 6
 %global sha_src_num 7
 %endif
@@ -58,8 +62,19 @@
 %global vers_arch3 s390x
 %global vers_arch4 aarch64
 %global vers_arch5 arm
+%global vers_arch6 riscv64
 %global src_num 8
 %global sha_src_num 9
+%endif
+%ifarch riscv64
+%global vers_arch x64
+%global vers_arch2 ppc64le
+%global vers_arch3 s390x
+%global vers_arch4 aarch64
+%global vers_arch5 arm
+%global vers_arch6 riscv64
+%global src_num 10
+%global sha_src_num 11
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch
@@ -81,7 +96,7 @@ Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 AutoReqProv: no
 Prefix: %{_libdir}/jvm/%{name}
 
-ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm}
+ExclusiveArch: x86_64 ppc64le s390x aarch64 %{arm} riscv64
 
 BuildRequires:  tar
 BuildRequires:  wget
@@ -124,6 +139,9 @@ Source7: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_ar
 # Fifth architecture (arm32)
 Source8: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source9: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch5}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
+# Sixth architecture (riscv64)
+Source10: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
+Source11: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch6}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}


### PR DESCRIPTION
Also Fixes #905 

Update the specfiles and jenkinsfile for the release of JDK17 for riscv64.

Also reverts the docker image update for the rpm package build to Fedora 38 to avoid the issue with gpg signing.