### PR TITLE
Add missing distributions for the JRE packages

### DIFF
--- a/linux/jre/debian/src/main/packaging/build.sh
+++ b/linux/jre/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="bookworm bullseye buster jammy focal bionic"
+debVersionList="trixie bookworm bullseye buster noble jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -35,13 +35,15 @@ public class DebianFlavours implements ArgumentsProvider {
 		 * Ubuntu policy: Current LTS versions, and development version.
 		 *     (https://wiki.ubuntu.com/Releases)
 		 */
-		return Stream.of(
-				Arguments.of("debian", "bookworm"), // Debian/12 (testing)
-				Arguments.of("debian", "bullseye"), // Debian/11 (stable)
-				Arguments.of("debian", "buster"),   // Debian/10 (oldstable)
-				Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
-				Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)
-				Arguments.of("ubuntu", "bionic")    // Ubuntu/18.04 (LTS)
-		);
+		 return Stream.of(
+        	        	Arguments.of("debian", "trixie"),   // Debian/13 (testing)
+                		Arguments.of("debian", "bookworm"), // Debian/12 (testing)
+                		Arguments.of("debian", "bullseye"), // Debian/11 (stable)
+                		Arguments.of("debian", "buster"),   // Debian/10 (oldstable)
+                		Arguments.of("ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
+                		Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
+                		Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)
+                		Arguments.of("ubuntu", "bionic")    // Ubuntu/18.04 (LTS)
+        	);
 	}
 }


### PR DESCRIPTION
Missing from PR: https://github.com/adoptium/installer/pull/868

Add the 2 new distributions for the jres.
