### PR TITLE
docs: update title and description for locale zh

### DIFF
--- a/wix/Lang/OpenJDK.Base.zh-cn.wxl.template
+++ b/wix/Lang/OpenJDK.Base.zh-cn.wxl.template
@@ -6,10 +6,10 @@
 	<String Id="ProductUrlUpdateInfo" Value="{product_update_info_link}" />
 	<String Id="OSVersionRequired" Value="Windows 7 or later is required." />
 	<String Id="ProductIsNotSupportedOnItanium" Value="This product is not supported on Itanium 64-bit systems." />
-	<String Id="FeatureEnvironmentTitle" Value="Add to PATH" />
-	<String Id="FeatureEnvironmentDescription" Value="Add to PATH environment variable." />
-	<String Id="FeatureJavaHomeTitle" Value="Set JAVA_HOME variable" />
-	<String Id="FeatureJavaHomeDescription" Value="Set JAVA_HOME environment variable." />
+	<String Id="FeatureEnvironmentTitle" Value="修改 PATH 变量值." />
+	<String Id="FeatureEnvironmentDescription" Value="通过将 JDK 安装路径添加到 PATH 值开头来修改 PATH 环境变量值." />
+	<String Id="FeatureJavaHomeTitle" Value="设置或重写 JAVA_HOME 变量." />
+	<String Id="FeatureJavaHomeDescription" Value="使用 JDK 安装路径来设置或重写 JAVA_HOME 环境变量值." />
 	<String Id="FeatureSourceTitle" Value="Source Code" />
 	<String Id="FeatureSourceDescription" Value="Source code for classes that comprise the public API of Java." />
 	<String Id="FeatureJarFileRunWithTitle" Value="Associate .jar" />
@@ -25,4 +25,6 @@
 	<String Id="CustomScopeDlgTitle" Value="{\WixUI_Font_Title}Installation Scope" />
 	<String Id="CustomScopeDlgPerUser" Value="Install &amp;just for you ([LogonUser])" />
 	<String Id="CustomScopeDlgPerMachine" Value="Install for all users of this &amp;machine" />
+	<String Id="BrowseDlg_Title" Value="浏览 [ProductName]" />
 </WixLocalization>
+	

--- a/wix/Lang/OpenJDK.Base.zh-tw.wxl.template
+++ b/wix/Lang/OpenJDK.Base.zh-tw.wxl.template
@@ -6,10 +6,10 @@
 	<String Id="ProductUrlUpdateInfo" Value="{product_update_info_link}" />
 	<String Id="OSVersionRequired" Value="Windows 7 or later is required." />
 	<String Id="ProductIsNotSupportedOnItanium" Value="This product is not supported on Itanium 64-bit systems." />
-	<String Id="FeatureEnvironmentTitle" Value="Add to PATH" />
-	<String Id="FeatureEnvironmentDescription" Value="Add to PATH environment variable." />
-	<String Id="FeatureJavaHomeTitle" Value="Set JAVA_HOME variable" />
-	<String Id="FeatureJavaHomeDescription" Value="Set JAVA_HOME environment variable." />
+	<String Id="FeatureEnvironmentTitle" Value="修改 PATH 變數值" />
+	<String Id="FeatureEnvironmentDescription" Value="將 JDK 安裝路徑新增至 PATH 值開頭來修改 PATH 環境變數值." />
+	<String Id="FeatureJavaHomeTitle" Value="設定或重寫 JAVA_HOME 變量" />
+	<String Id="FeatureJavaHomeDescription" Value="使用 JDK 安裝路徑來設定或重寫 JAVA_HOME 環境變數值." />
 	<String Id="FeatureSourceTitle" Value="Source Code" />
 	<String Id="FeatureSourceDescription" Value="Source code for classes that comprise the public API of Java." />
 	<String Id="FeatureJarFileRunWithTitle" Value="Associate .jar" />
@@ -25,4 +25,5 @@
 	<String Id="CustomScopeDlgTitle" Value="{\WixUI_Font_Title}Installation Scope" />
 	<String Id="CustomScopeDlgPerUser" Value="Install &amp;just for you ([LogonUser])" />
 	<String Id="CustomScopeDlgPerMachine" Value="Install for all users of this &amp;machine" />
+	<String Id="BrowseDlg_Title" Value="瀏覽 [ProductName]" />
 </WixLocalization>


### PR DESCRIPTION
translation is based on changes from https://github.com/adoptium/installer/pull/945/files
```
<String Id="FeatureEnvironmentTitle" Value="Modify PATH variable" />
<String Id="FeatureEnvironmentDescription" Value="Modify PATH environment variable by prepending the JDK installation directory to the beginning of PATH." />
<String Id="FeatureJavaHomeTitle" Value="Set or override JAVA_HOME variable" />
<String Id="FeatureJavaHomeDescription" Value="Sets or overrides JAVA_HOME environment variable with the JDK installation directory." />
<String Id="BrowseDlg_Title" Value="[ProductName] Browse" />
```