### PR TITLE
JULY CPU - JDK8 & JDK11 Updates For Shipping Linux Packages

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.23_p9
+pkgver=11.0.24_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -95,7 +95,7 @@ _jdk() {
 }
 
 sha256sums="
-b45c467be52fe11ffd9bf69b3a035068134b305053874de4f3b3c5e5e1419659  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+ae988c72eeb2d78bb729a3387601ce0ea84305734ebdbe95d276f39952a8e019  OpenJDK11U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 22d2ff9757549ebc64e09afd3423f84b5690dcf972cd6535211c07c66d38fab0  TestCryptoLevel.java
 9fb00c7b0220de8f3ee2aa398459a37d119f43fd63321530a00b3bb9217dd933  TestECDSA.java

--- a/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jdk/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jdk
-pkgver=8.412.08
+pkgver=8.422.05
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -67,6 +67,6 @@ package() {
 }
 
 sha256sums="
-409091665e5f8cf678938bbbc0d377122ef8bad7b1c97a0f809da054db956e51  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+525a7731331cad502b9293ccb4ac2b13e85516736e98a57cb27c2767005188e1  OpenJDK8U-jdk_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 e9185736dde99a4dc570a645a20407bdb41c1f48dfc34d9c3eb246cf0435a378  HelloWorld.java
 "

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jdk (11.0.24.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.24.0.0+8 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Jul 2024 00:00:00 +0000
+
 temurin-11-jdk (11.0.23.0.0+9) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.23.0.0+9 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jdk
 priority = 1111
 jvm_tools = jaotc jar jarsigner java javac javadoc javap jcmd jconsole jdb jdeprscan jdeps jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200 jexec jspawnhelper
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.23_9.tar.gz
-amd64_checksum = 23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.23_9.tar.gz
-arm64_checksum = e00476a7be3c4adfa9b3d55d30768967fd246a8352e518894e183fa444d4d3ce
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.23_9.tar.gz
-armhf_checksum = 8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.23_9.tar.gz
-ppc64el_checksum = f56068bb64c6bf858894f75c2bc261f54db32932422eb07527f36ae40046e9a0
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.23_9.tar.gz
-s390x_checksum = cf06c3e41acfaeda77112ac04f5a711cafe9fa9ac04dff758696fe7e8d66a0ea
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.24_8.tar.gz
+amd64_checksum = 0e71a01563a5c7b9988a168b0c4ce720a6dff966b3c27bb29d1ded461ff71d0e
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.24_8.tar.gz
+arm64_checksum = 04e21301fedc76841fb03929ac6cacfbbda30b5693acfd515a8f34d4a0cdeb28
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_arm_linux_hotspot_11.0.24_8.tar.gz
+armhf_checksum = 9d14a076d1440161ab4c9736644e8e9f4719eb8e9f44c03470640960c3cd5e00
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.24_8.tar.gz
+ppc64el_checksum = 4dfdc498938a159c592a2f094576f09c94999e17327c1f5ff81794694992054d
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.24_8.tar.gz
+s390x_checksum = 7f049af5d3ff8794d07da1c31752e18e204653930f1d422e2d42905c90c1c408
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jdk (8.0.422.0.0+5) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.422.0.0+5 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, Jul 17 2024 00:00:00 +0000
+
 temurin-8-jdk (8.0.412.0.0+8) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.412.0.0+8 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jdk
 priority = 1081
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = appletviewer clhsdb extcheck hsdb idlj jar jarsigner java javac javadoc javah javap jcmd jconsole jdb jdeps jfr jhat jinfo jjs jmap jps jrunscript jsadebugd jstack jstat jstatd keytool native2ascii orbd pack200 policytool rmic rmid rmiregistry schemagen serialver servertool tnameserv unpack200 wsgen wsimport xjc jexec
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u412b08.tar.gz
-amd64_checksum = b9884a96f78543276a6399c3eb8c2fd8a80e6b432ea50e87d3d12d495d1d2808
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u412b08.tar.gz
-arm64_checksum = 3504d748a93f23cac8c060bd33231bd51e90dcb620f38dadc6239b6cd2a5011c
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_arm_linux_hotspot_8u412b08.tar.gz
-armhf_checksum = be4aff6fa7bf6515f16f93dcaf9fdc61853fe1ef0d25b08a1bb1cf6e3d047391
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u412b08.tar.gz
-ppc64el_checksum = 6b7ed7996788075e182dd33349288346240fbce540e50fd77aecfc309a5ada19
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u422b05.tar.gz
+amd64_checksum = 4c6056f6167fae73ace7c3080b78940be5c87d54f5b08894b3517eed1cbb2c06
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_aarch64_linux_hotspot_8u422b05.tar.gz
+arm64_checksum = af98a839ec238106078bd360af9e405dc6665c05ee837178ed13b92193681923
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_arm_linux_hotspot_8u422b05.tar.gz
+armhf_checksum = 5bd0203b2b09b033e3a762299a4975939d7571b433eab8b59340cc966102bef1
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u422b05.tar.gz
+ppc64el_checksum = 78fbd7b01204cdf90bcb3f9fe6a8e9432bdaa75776fa333aa9cbcb5a79de34cd
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jdk/redhat/src/main/packaging/build.sh
+++ b/linux/jdk/redhat/src/main/packaging/build.sh
@@ -63,5 +63,9 @@ done;
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign.
 if grep -q %_gpg_name /home/builder/.rpmmacros; then
-	rpmsign --addsign /home/builder/out/*.rpm
-fi
+	rm -f ~/.gnupg/public-keys.d/pubring.db.lock
+	for file in `ls /home/builder/out/*.rpm`; do
+		echo Signing: $file
+	  rpmsign --addsign $file
+  done
+fi;

--- a/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.23+9
+%global upstream_version 11.0.24+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.23.0.0.9
+%global spec_version 11.0.24.0.0.8
 %global spec_release 1
 %global priority 1111
 
@@ -264,6 +264,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.24.0.0.8-1
+- Eclipse Temurin 11.0.24.0+8 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
 - Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u412-b08
+%global upstream_version 8u422-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.412.0.0.8
+%global spec_version 8.0.422.0.0.5
 %global spec_release 1
 %global priority 1081
 
@@ -278,6 +278,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.422.0.0.5-1
+- Eclipse Temurin 8.0.422-b05 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
 - Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1

--- a/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/redhat/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-b08-aarch32-20240419
+%global upstream_version 8u422-b05-aarch32-20240718
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jdk/suse/src/main/packaging/build.sh
+++ b/linux/jdk/suse/src/main/packaging/build.sh
@@ -34,5 +34,9 @@ done;
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign
 if grep -q %_gpg_name /home/builder/.rpmmacros; then
-	rpmsign --addsign /home/builder/out/*.rpm
+	rm -f ~/.gnupg/public-keys.d/pubring.db.lock
+	for file in `ls /home/builder/out/*.rpm`; do
+		echo Signing: $file
+		rpmsign --addsign $file
+	done
 fi;

--- a/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/11/temurin-11-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.23+9
+%global upstream_version 11.0.24+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.23.0.0.9
+%global spec_version 11.0.24.0.0.8
 %global spec_release 1
 %global priority 1111
 
@@ -255,6 +255,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.24.0.0.8-1
+- Eclipse Temurin 11.0.24.0+8 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
 - Eclipse Temurin 11.0.23.0+9 release.
 * Mon Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u412-b08
+%global upstream_version 8u422-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.412.0.0.8
+%global spec_version 8.0.422.0.0.5
 %global spec_release 1
 %global priority 1081
 
@@ -268,6 +268,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.422.0.0.5-1
+- Eclipse Temurin 8.0.422-b05 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
 - Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1

--- a/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
+++ b/linux/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jdk8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-b08-aarch32-20240419
+%global upstream_version 8u422-b05-aarch32-20240718
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/11/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-11
-pkgver=11.0.23_p9
+pkgver=11.0.24_p8
 # replace _p1 with _1
 _pkgver=${pkgver/_p/_}
 _pkgverplus=${pkgver/_p/+}
@@ -72,5 +72,5 @@ _jre() {
 }
 
 sha256sums="
-6972a6251bc88d6fbb64a188557cf165f1c415ded550d2a280bbcbc4272caff1  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+0ac795729cc11f47323a71713eac2a5b22d4615fd9b66c8766f964c03fb6e160  OpenJDK11U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
+++ b/linux/jre/alpine/src/main/packaging/temurin/8/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 pkgname=temurin-8-jre
-pkgver=8.412.08
+pkgver=8.422.05
 # replace 8. with 8u and .01 with b-01
 _pkgver=${pkgver/8./8u}
 _pkgver=${_pkgver%.*}b${_pkgver#*.}
@@ -60,5 +60,5 @@ ls ${srcdir}
 }
 
 sha256sums="
-c82962d7378d1fd415db594fce6ec047939e9fab5301fa4407cd7faea9ea7e31  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
+9a7a939638b9cdaa8e1a119b8f21bfdd4cb2390b8a47cc27ccf9effc90f4b437  OpenJDK8U-jre_x64_alpine-linux_hotspot_$_pkgver.tar.gz
 "

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jre (11.0.24.0.0+8) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.24.0.0+8 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, 17 Jul 2024 00:00:00 +0000
+
 temurin-11-jre (11.0.23.0.0+9) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.23.0.0+9 release.

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/rules
@@ -3,16 +3,16 @@
 pkg_name = temurin-11-jre
 priority = 1112
 jvm_tools = jaotc java jfr jjs jrunscript keytool pack200 rmid rmiregistry unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.23_9.tar.gz
-amd64_checksum = 786a72296189ba8e43999532aa73730d87ec1fce558eb3c4e98b611b423375e3
-arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.23_9.tar.gz
-arm64_checksum = 7290ace47a030d89ea023c28e7aa555c9da72b4194f73b39ec9d058011bf06dd
-armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.23_9.tar.gz
-armhf_checksum = 025f994549708f7291ce3b0fa7c41f7e78ec3af3eae3f85fffe9c5fa4a54889f
-ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.23_9.tar.gz
-ppc64el_checksum = 3b3fbd324620fd914bd8462e292124493fcf846fd69195c4b9a231131dc68d5f
-s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_s390x_linux_hotspot_11.0.23_9.tar.gz
-s390x_checksum = 25abb7f74f55847b0d509402111084bd7a244d904744f3bfffa89528bc3b8a69
+amd64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_x64_linux_hotspot_11.0.24_8.tar.gz
+amd64_checksum = e0c1938093da3780e4494d366a4e6b75584dde8d46a19acea6691ae11df4cda5
+arm64_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.24_8.tar.gz
+arm64_checksum = 1fe97cdaad47d7d108f329c6e4560b46748ef7f2948a1027812ade0bbc2a3597
+armhf_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_arm_linux_hotspot_11.0.24_8.tar.gz
+armhf_checksum = bf893085627c6ec484e63aa1290276b23bcfee547459da6b0432ae9c5c1be22a
+ppc64el_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.24_8.tar.gz
+ppc64el_checksum = 8ee351314182df93fbad96139bb74b97814944d66197896e388404a1ecfa06b3
+s390x_tarball_url = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.24%2B8/OpenJDK11U-jre_s390x_linux_hotspot_11.0.24_8.tar.gz
+s390x_checksum = 5b331f093bb03126334bbbc24f05f60681baeda461d860e4e2cdb693ee54e0ed
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/rules
@@ -14,7 +14,7 @@ ppc64el_checksum = 2759c48e1e56117871b04c851af18b92b6992cf67590f602949b96c3cff15
 s390x_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_s390x_linux_hotspot_17.0.12_7.tar.gz
 s390x_checksum = cb1a3857d10e9353862761ce3c6b45573a736ea95cea44bc02dc3a703e57255a
 riscv64_tarball_url = https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_riscv64_linux_hotspot_17.0.12_7.tar.gz
-riscv64_checksum = 63bae276cc322532b451ae7473127c92a75db16cc95473577f133cd09349822a
+riscv64_checksum = 2d1ed42918305a1a0754a6e1e9294c7d4d7fda4bff6dba7bc5682037d860dbc9
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jre (8.0.422.0.0+5) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.422.0.0+5 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Wed, Jul 17 2024 00:00:00 +0000
+
 temurin-8-jre (8.0.412.0.0+8) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.412.0.0+8 release.

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/rules
@@ -4,14 +4,14 @@ pkg_name = temurin-8-jre
 priority = 1082
 # The list below must be kept in sync with the jinfo.in file
 jvm_tools = java jjs keytool orbd pack200 policytool rmid rmiregistry servertool tnameserv unpack200
-amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz
-amd64_checksum = a8d994332a2ff15d48bf04405c3b2f6bd331a928dd96639b15e62891f7172363
-arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_aarch64_linux_hotspot_8u412b08.tar.gz
-arm64_checksum = 17550a6a4ddf71ac81ba8f276467bc58f036c123c0f1bafcafd69f70e3e49cf5
-armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_arm_linux_hotspot_8u412b08.tar.gz
-armhf_checksum = 1a6b470ac83b241223447a1e6cb55c4a8f78af0146b9387e9842625041226654
-ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u412b08.tar.gz
-ppc64el_checksum = d3157230c01b320e47ad6df650e83b15f8f76294d0df9f1c03867d07fe2883c9
+amd64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_x64_linux_hotspot_8u422b05.tar.gz
+amd64_checksum = 0ac516cc1eadffb4cd3cfc9736a33d58ea6a396bf85729036c973482f7c063d9
+arm64_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_aarch64_linux_hotspot_8u422b05.tar.gz
+arm64_checksum = 8fbefff2c578f73d95118d830347589ddc9aa84510200a5a5001901c2dea4810
+armhf_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_arm_linux_hotspot_8u422b05.tar.gz
+armhf_checksum = 13bdefdeae6f18bc9c87bba18c853b8b12c5442ce07ff0a3956ce28776d695ff
+ppc64el_tarball_url = https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jre_ppc64le_linux_hotspot_8u422b05.tar.gz
+ppc64el_checksum = 2991edbedee448c0f1edf131beca84b415dac64ea97365b9bfd85bc2f39893bb
 
 d = debian/$(pkg_name)
 jvm_home = usr/lib/jvm

--- a/linux/jre/redhat/src/main/packaging/build.sh
+++ b/linux/jre/redhat/src/main/packaging/build.sh
@@ -61,5 +61,9 @@ done;
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign.
 if grep -q %_gpg_name /home/builder/.rpmmacros; then
-	rpmsign --addsign /home/builder/out/*.rpm
+	rm -f ~/.gnupg/public-keys.d/pubring.db.lock
+	for file in `ls /home/builder/out/*.rpm`; do
+		echo Signing: $file
+		rpmsign --addsign $file
+	done
 fi;

--- a/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.23+9
+%global upstream_version 11.0.24+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.23.0.0.9
+%global spec_version 11.0.24.0.0.8
 %global spec_release 1
 %global priority 1112
 
@@ -199,6 +199,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.24.0.0.8-1
+- Eclipse Temurin 11.0.24.0+8 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
 - Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-b08-aarch32-20240419
+%global upstream_version 8u422-b05-aarch32-20240718
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch

--- a/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/redhat/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u412-b08
+%global upstream_version 8u422-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.412.0.0.8
+%global spec_version 8.0.422.0.0.5
 %global spec_release 1
 %global priority 1082
 
@@ -192,6 +192,8 @@ fi
 /usr/lib/tmpfiles.d/%{name}.conf
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.422.0.0.5-1
+- Eclipse Temurin 8.0.422-b05 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
 - Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1

--- a/linux/jre/suse/src/main/packaging/build.sh
+++ b/linux/jre/suse/src/main/packaging/build.sh
@@ -34,5 +34,9 @@ done;
 find /home/builder/rpmbuild/SRPMS /home/builder/rpmbuild/RPMS -type f -name "*.rpm" -print0 | xargs -0 -I {} cp {} /home/builder/out
 # Sign generated RPMs with rpmsign
 if grep -q %_gpg_name /home/builder/.rpmmacros; then
-	rpmsign --addsign /home/builder/out/*.rpm
+	rm -f ~/.gnupg/public-keys.d/pubring.db.lock
+	for file in `ls /home/builder/out/*.rpm`; do
+		echo Signing: $file
+	  rpmsign --addsign $file
+  done
 fi;

--- a/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/11/temurin-11-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 11.0.23+9
+%global upstream_version 11.0.24+8
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 11.0.13.0.1___7 11.0.13.0.0+8
 #  11.0.13.0.0___8 == 11.0.13.0.0+8
-%global spec_version 11.0.23.0.0.9
+%global spec_version 11.0.24.0.0.8
 %global spec_release 1
 %global priority 1112
 
@@ -190,6 +190,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.24.0.0.8-1
+- Eclipse Temurin 11.0.24.0+8 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.23.0.0.9-1
 - Eclipse Temurin 11.0.23.0+9 release.
 * Tue Jan 23 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 11.0.22.0.0.7-1

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -1,10 +1,10 @@
-%global upstream_version 8u412-b08
+%global upstream_version 8u422-b05
 # Only [A-Za-z0-9.] allowed in version:
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_upstream_uses_invalid_characters_in_the_version
 # also not very intuitive:
 #  $ rpmdev-vercmp 8.0.312.0.1___8 8.0.312.0.0+7
 #  8.0.312.0.0___7 == 8.0.312.0.0+7
-%global spec_version 8.0.412.0.0.8
+%global spec_version 8.0.422.0.0.5
 %global spec_release 1
 %global priority 1082
 
@@ -182,6 +182,8 @@ fi
 %{prefix}
 
 %changelog
+* Wed Jul 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.422.0.0.5-1
+- Eclipse Temurin 8.0.422-b05 release.
 * Wed Apr 17 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.412.0.0.8-1
 - Eclipse Temurin 8.0.412-b08 release.
 * Wed Jan 24 2024 Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> 8.0.402.0.0.6-1

--- a/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
+++ b/linux/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.spec
@@ -47,7 +47,7 @@
 %global src_num 6
 %global sha_src_num 7
 # jre8 arm32 has different top directory name https://github.com/adoptium/temurin-build/issues/2795
-%global upstream_version 8u412-b08-aarch32-20240419
+%global upstream_version 8u422-b05-aarch32-20240718
 %endif
 # Allow for noarch SRPM build
 %ifarch noarch


### PR DESCRIPTION
Updates required for JDK8 & JDK11 Alpine, Debian, RH & SUSE packages.

Also includes a fix, which was preventing GPG signing from working.

Testing ok.