### PR TITLE
Stable default location

### DIFF
--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -46,16 +46,16 @@
       <?define OracleJavasoftBaseKey="JRE" ?>
     <?else?>
       <?define OracleJavasoftBaseKey="JDK" ?>
-    <?endif?>            
+    <?endif?>
   <?else?>
     <?define OracleVersionKey="1.8" ?>
     <?if $(env.PRODUCT_CATEGORY)="jre"?>
       <?define OracleJavasoftBaseKey="Java Runtime Environment" ?>
     <?else?>
       <?define OracleJavasoftBaseKey="Java Development Kit" ?>
-    <?endif?>    
+    <?endif?>
   <?endif?>
-  
+
   <?if $(var.JVM)="openj9" ?>
     <?define license="license-OpenJ9.en-us.rtf" ?>
     <?define license_shown="1" ?>
@@ -92,7 +92,7 @@
   <?else?>
     <?define DllPath="no DllPath known for $(var.JVM)" ?>
   <?endif?>
-  
+
   <!-- Static settings, DO NOT TOUCH or upgrades will break! -->
   <?define RTMProductVersion="1.0.0" ?>
 </Include>

--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -27,7 +27,7 @@
     <?define FeatureMainDescription="!(loc.JREFeatureMainDescription)" ?>
 
     <?define ProductCategory="JRE" ?>
-    <?define AppFolder="jre-$(var.ProductVersion)-$(var.JVM)" ?>
+    <?define AppFolder="jre-$(var.ProductMajorVersion)-$(var.JVM)" ?>
   <?else?>
     <?define ProductName="!(loc.JDKProductName)" ?>
     <?define ProductNameWithVersion="!(loc.JDKProductName) $(var.ProductVersionString) $(var.Arch)" ?>
@@ -36,7 +36,7 @@
     <?define FeatureMainDescription="!(loc.JDKFeatureMainDescription)" ?>
 
     <?define ProductCategory="JDK" ?>
-    <?define AppFolder="jdk-$(var.ProductVersion)-$(var.JVM)" ?>
+    <?define AppFolder="jdk-$(var.ProductMajorVersion)-$(var.JVM)" ?>
   <?endif?>
 
   <!-- Registry key change with new numbering format since Java 9 -->

--- a/wix/Includes/OpenJDK.Variables.wxi.template
+++ b/wix/Includes/OpenJDK.Variables.wxi.template
@@ -27,7 +27,7 @@
     <?define FeatureMainDescription="!(loc.JREFeatureMainDescription)" ?>
 
     <?define ProductCategory="JRE" ?>
-    <?define AppFolder="jre-$(var.ProductMajorVersion)-$(var.JVM)" ?>
+    <?define AppFolder="temurin-$(var.ProductMajorVersion)-jre" ?>
   <?else?>
     <?define ProductName="!(loc.JDKProductName)" ?>
     <?define ProductNameWithVersion="!(loc.JDKProductName) $(var.ProductVersionString) $(var.Arch)" ?>
@@ -36,7 +36,7 @@
     <?define FeatureMainDescription="!(loc.JDKFeatureMainDescription)" ?>
 
     <?define ProductCategory="JDK" ?>
-    <?define AppFolder="jdk-$(var.ProductMajorVersion)-$(var.JVM)" ?>
+    <?define AppFolder="temurin-$(var.ProductMajorVersion)-jdk" ?>
   <?endif?>
 
   <!-- Registry key change with new numbering format since Java 9 -->


### PR DESCRIPTION
As discussed in https://github.com/adoptium/installer/pull/789 I created a separate PR with effectively the same changes taking into account the proposal from https://github.com/adoptium/installer/pull/789#issuecomment-2306065205.

The default location should now be `temurin-<ver>-<jdk|jre>` in the installer with these changes.

I did not find any variable / localization reference in the installer code base that contains the required `temurin` string. I can change that from the current hardcoded string, of course, but would need a little input/guidance on what to do.