### PR TITLE
Add Fedora 41 & 42 distributions.

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -584,6 +584,8 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch, String Version) {
             'rpm/fedora/38',
             'rpm/fedora/39',
             'rpm/fedora/40',
+            'rpm/fedora/41',
+            'rpm/fedora/42',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',
             'rpm/amazonlinux/2'


### PR DESCRIPTION
Fixes #1053 

Add fedora 41 & 42 distributions, so that installer rpms can be pushed to artifactory.