### PR TITLE
Update SDK version used by WiX installer to one that we install with VS2022

### DIFF
--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -82,7 +82,7 @@ IF "%SKIP_MSI_VALIDATION%" == "true" (
 REM Configure available SDK version:
 REM See folder e.g. "C:\Program Files (x86)\Windows Kits\[10]\bin\[10.0.16299.0]\x64"
 SET WIN_SDK_MAJOR_VERSION=10
-SET WIN_SDK_FULL_VERSION=10.0.17763.0
+SET WIN_SDK_FULL_VERSION=10.0.22621.0
 SET WORKDIR=Workdir\
 mkdir %WORKDIR%
 


### PR DESCRIPTION
The 10.0.17763.0 is not installed on machines where we install VS2022 from Build Tools. It is assumed that it was installed via some of the earlier VS version roles in our playbooks. This PR updates the version used by the WiX installer so that it will currently run on machines which have only had the VS2022 compiler (the one used by all of the Temurin builds now).

Without this fix it fails when trying to do some locale related activities. Found as part of https://github.com/adoptium/infrastructure/issues/3286#issuecomment-2504207097

```
Building setup translation for culture "de-de" with LangID "1031"...
Input Error: Can not find script file "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\WiLangId.vbs".
WiLangId failed with : 1
Failed to generate setup translation of culture "de-de" with LangID "1031".
failed to build translation de-de 1031
```

This fix has been tested and the installer job runs to completion successfully. If desired for testing, a JDK24 JRE artifact created with this can be located at https://ci.adoptium.net/job/build-scripts/job/release/job/create_installer_windows_22621/4/artifact/wix/ReleaseDir/OpenJDK-jre_x64_windows_hotspot_24_26-ea.msi and should be equivalent to the one from the main pipelines at https://ci.adoptium.net/job/build-scripts/job/release/job/create_installer_windows/1127/artifact/wix/ReleaseDir/OpenJDK-jre_x64_windows_hotspot_24_26-ea.msi