### PR TITLE
Bump package version for Debian republish

### DIFF
--- a/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jdk (11.0.25.0.0+9-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.25.0.0+9-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, Dec 19 2024 00:00:00 +0000
+
 temurin-11-jdk (11.0.25.0.0+9) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.25.0.0+9 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jdk (17.0.13.0.0+11-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.13.0.0+11-1 release.
+
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 08:00:00 +0000
+
 temurin-17-jdk (17.0.13.0.0+11) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.13.0.0+11 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,3 +1,9 @@
+temurin-21-jdk (21.0.5.0.0+11-2) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.5.0.0+11-2 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 00:00:00 +0000
+
 temurin-21-jdk (21.0.5.0.0+11-1) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.5.0.0+11-1 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/23/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/23/debian/changelog
@@ -1,3 +1,9 @@
+temurin-23-jdk (23.0.1.0.0+11-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 23.0.1.0.0+11-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 00:00:00 +0000
+
 temurin-23-jdk (23.0.1.0.0+11) STABLE; urgency=medium
 
   * Eclipse Temurin 23.0.1.0.0+11 release.

--- a/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jdk/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jdk (8.0.432.0.0+6-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.432.0.0+6-1 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, Dec 19 2024 00:00:00 +0000
+
 temurin-8-jdk (8.0.432.0.0+6) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.432.0.0+6 release.

--- a/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/11/debian/changelog
@@ -1,3 +1,9 @@
+temurin-11-jre (11.0.25.0.0+9-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 11.0.25.0.0+9-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 00:00:00 +0000
+
 temurin-11-jre (11.0.25.0.0+9) STABLE; urgency=medium
 
   * Eclipse Temurin 11.0.25.0.0+9 release.

--- a/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/17/debian/changelog
@@ -1,3 +1,9 @@
+temurin-17-jre (17.0.13.0.0+11-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 17.0.13.0.0+11-1 release.
+
+  -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 08:00:00 +000
+
 temurin-17-jre (17.0.13.0.0+11) STABLE; urgency=medium
 
   * Eclipse Temurin 17.0.13.0.0+11 release.

--- a/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/21/debian/changelog
@@ -1,3 +1,9 @@
+temurin-21-jre (21.0.5.0.0+11-2) STABLE; urgency=medium
+
+  * Eclipse Temurin 21.0.5.0.0+11-2 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 00:00:00 +0000
+
 temurin-21-jre (21.0.5.0.0+11-1) STABLE; urgency=medium
 
   * Eclipse Temurin 21.0.5.0.0+11-1 release.

--- a/linux/jre/debian/src/main/packaging/temurin/23/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/23/debian/changelog
@@ -1,3 +1,9 @@
+temurin-23-jre (23.0.1.0.0+11-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 23.0.1.0.0+11-1 release.
+
+ -- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, 19 Dec 2024 00:00:00 +0000
+
 temurin-23-jre (23.0.1.0.0+11-0) STABLE; urgency=medium
 
   * Eclipse Temurin 23.0.1.0.0+11-0 release.

--- a/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
+++ b/linux/jre/debian/src/main/packaging/temurin/8/debian/changelog
@@ -1,3 +1,9 @@
+temurin-8-jre (8.0.432.0.0+6-1) STABLE; urgency=medium
+
+  * Eclipse Temurin 8.0.432.0.0+6-1 release.
+
+-- Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>  Thu, Dec 19 2024 00:00:00 +0000
+
 temurin-8-jre (8.0.432.0.0+6) STABLE; urgency=medium
 
   * Eclipse Temurin 8.0.432.0.0+6 release.


### PR DESCRIPTION
Following the merge of https://github.com/adoptium/installer/pull/1075 

A new version of the debian packages is required to be published to make them available for Ubuntu 24.10