### PR TITLE
BugFix : Update automated installer production to validate architecture per distro

### DIFF
--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -323,11 +323,18 @@ pipeline {
                         error("The Artifacts contain multiple architectures: ${extractedArchs}")
                     }
 
-                    // Derive Node To Build Packages On
-
-                    PKGBUILDLABELAPK = getPackageBuildLabel(arch, 'APK')
-                    PKGBUILDLABELDEB = getPackageBuildLabel(arch, 'DEB')
-                    PKGBUILDLABELRHEL = getPackageBuildLabel(arch, 'RHEL')
+                     if (params.ARTIFACTS_TO_COPY.contains('alpine-linux')) {
+                        // Derive Node To Build Alpine Packages On
+                        PKGBUILDLABELAPK = getPackageBuildLabel(arch, 'APK')
+                    } else if (params.ARTIFACTS_TO_COPY.contains('linux')) {
+                        // Derive Node To Build Linux Packages On
+                        PKGBUILDLABELDEB = getPackageBuildLabel(arch, 'DEB')
+                        PKGBUILDLABELRHEL = getPackageBuildLabel(arch, 'RHEL')
+                    } else {
+                        println "WARNING: The Artifacts Are For Neither Linux OR Alpine - So I Cant Determine Appropriate Node Labels"
+                        currentBuild.result = 'UNSTABLE' // Also Consider NOT_BUILT
+                        error("Pipeline Skipped Due To Triggered For Neither Alpine Or Linux")
+                    }
 
                     // Map Architectures From Source To Dist Suitable Values
 

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -250,6 +250,14 @@ pipeline {
         booleanParam(name: 'REPACKAGE', defaultValue: false, description: 'Tick if this is a republish of an existing package, ie xx.xxx.2 , rather than the base release of a package (1)')
         string(name: 'PACKAGE_INCREMENT', defaultValue: '1', description: 'This is the incremental number used for re-releases of package versions - Should be set appropriately if RePackage is True')
         string(name: 'TEMURIN_VERSION_INCREMENT', defaultValue: '0', description: 'Final Element Of The Version Number - Used For Temurin Specific Patches - NEARLY ALWAYS ZERO')
+
+        // Handle Parameters From Upstream Job That Are Not Required.
+        string(name: 'UPSTREAM_JOB_NAME', defaultValue: '', description: 'Parameter From Upstream Job Not Required Here')
+        string(name: 'UPSTREAM_JOB_NUMBER', defaultValue: '', description: 'Parameter From Upstream Job Not Required Here')
+        booleanParam(name: 'UPLOAD_TESTRESULTS_ONLY', defaultValue: false, description: 'Parameter From Upstream Job Not Required Here')
+        string(name: 'TIMESTAMP', defaultValue: '', description: 'Parameter From Upstream Job Not Required Here')
+        string(name: 'GITHUB_TOKEN', defaultValue: '', description: 'Parameter From Upstream Job Not Required Here')
+        string(name: 'ARTIFACTS_TO_SKIP', defaultValue: '', description: 'Parameter From Upstream Job Not Required Here')
     }
     // Stage Definition - Start
     stages {
@@ -289,7 +297,7 @@ pipeline {
                     } else if (params.ARTIFACTS_TO_COPY.contains('linux')) {
                         distro = "linux"
                     } else {
-                        printlin "WARNING: The Artifacts Are For Neither Linux OR Alpine"
+                        println "WARNING: The Artifacts Are For Neither Linux OR Alpine"
                         currentBuild.result = 'UNSTABLE' // Also Consider NOT_BUILT
                         error("Pipeline Skipped Due To Triggered For Neither Alpine Or Linux")
                     }


### PR DESCRIPTION
A bug was spotted during the release cycle, whereby it was incorrectly trying to determine which alpine node to build on for a non alpine package build.

This bug fix amends the node identification to be based on the type of packages ( alpine / or non alpine ) being built.

Part of #1005