### PR TITLE
Bugfix: Automatically generated linux installer packages are not being signed.

### DIFF
--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -754,6 +754,7 @@ stage('Build & Archive Package') {
                         def privateKey = 'adoptium-artifactory-gpg-key'
                         withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
                            buildCli += " -PGPG_KEY=${env.GPG_KEY}"
+                           buildCli = params.ENABLEDEBUG.toBoolean() ? buildCli + ' --stacktrace' : buildCli
                            sh("$buildCli")
                         }
                     }
@@ -763,11 +764,13 @@ stage('Build & Archive Package') {
                         def privateKey = 'adoptium-artifactory-rsa-key'
                         withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
                            buildCli += " -PGPG_KEY=${env.GPG_KEY}"
+                           buildCli = params.ENABLEDEBUG.toBoolean() ? buildCli + ' --stacktrace' : buildCli
                            sh("$buildCli")
                         }
                     }
                 } else {
                     echo "Building Without Signing"
+                    buildCli = params.ENABLEDEBUG.toBoolean() ? buildCli + ' --stacktrace' : buildCli
                     sh("$buildCli")
                 }
             }

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -743,15 +743,33 @@ stage('Build & Archive Package') {
                 }
 
                 if (params.ENABLEGPGSIGNING) {
-                    def privateKey = 'adoptium-artifactory-rsa-key'
-                    withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
-                        buildCli += " -PGPG_KEY_PATH=${GPG_KEY}"
+                    if (DistArrayElement =="debian") {
+                        echo "Debian Does Not Use Signing"
+                        buildCli = params.ENABLEDEBUG.toBoolean() ? buildCli + ' --stacktrace' : buildCli
+                        sh("$buildCli")
                     }
+                    
+                    if (DistArrayElement == "rhel" || DistArrayElement == "suse") { // for RPM based: RedHat / Suse / Alpine
+                        echo "Using RPM Private KEY"
+                        def privateKey = 'adoptium-artifactory-gpg-key'
+                        withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
+                           buildCli += " -PGPG_KEY=${env.GPG_KEY}"
+                           sh("$buildCli")
+                        }
+                    }
+                        
+                    if (DistArrayElement == "alpine") {
+                        echo "Using Alpine Private KEY"
+                        def privateKey = 'adoptium-artifactory-rsa-key'
+                        withCredentials([file(credentialsId: privateKey, variable: 'GPG_KEY')]) {
+                           buildCli += " -PGPG_KEY=${env.GPG_KEY}"
+                           sh("$buildCli")
+                        }
+                    }
+                } else {
+                    echo "Building Without Signing"
+                    sh("$buildCli")
                 }
-
-                buildCli = params.ENABLEDEBUG.toBoolean() ? buildCli + ' --stacktrace' : buildCli
-                // echo "Build CLI : ${buildCli}"
-                sh("$buildCli")
             }
         } catch (Exception ex) {
             echo "Exception in build for ${DistArrayElement}: ${ex}"


### PR DESCRIPTION
Fixes #1110 

The passing of the relevant key to the gradle builds to produced sign rpms & apks was not working correctly due to the calling of the gradle build outside of the withCredentials block.

Alpine needs the rsa gpg key  
Rhel / Suse need the gpg key  
Debian does not use the jenkins provided gpg key.

This code explicitly forces each package type to be built and signed correctly.

Once this is merged, I'll push updated packages for everything that has already been released.