### PR TITLE
Package Build Fixes Post Release Cycle

### DIFF
--- a/linux/jdk/alpine/src/main/packaging/entrypoint.sh
+++ b/linux/jdk/alpine/src/main/packaging/entrypoint.sh
@@ -8,6 +8,7 @@ cp -R /home/builder/build/generated/packaging /home/builder/workspace
 
 # Install Adoptium Public Key
 sudo chmod 664 /etc/apk/repositories
+sudo chmod 775 /etc/apk/keys
 sudo chgrp abuild /etc/apk/repositories
 sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories

--- a/linux/jre/alpine/src/main/packaging/entrypoint.sh
+++ b/linux/jre/alpine/src/main/packaging/entrypoint.sh
@@ -8,6 +8,7 @@ cp -R /home/builder/build/generated/packaging /home/builder/workspace
 
 # Install Adoptium Public Key
 sudo chmod 664 /etc/apk/repositories
+sudo chmod 775 /etc/apk/keys
 sudo chgrp abuild /etc/apk/repositories
 sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -134,7 +134,7 @@ def getPackageBuildLabel(String arch, String distro) {
     switch (distro) {
         case 'APK':
             if (arch == 'x64') {
-                return 'linux&&build&&x64&&dockerBuild'
+                return 'build&&linux&&x64&&dockerBuild&&dynamicAzure'
             } else if (arch == 'aarch64') {
                 return 'build&&docker&&linux&&aarch64&&apkbuild'
             } else {

--- a/linux_new/jdk/alpine/src/main/packaging/entrypoint.sh
+++ b/linux_new/jdk/alpine/src/main/packaging/entrypoint.sh
@@ -8,6 +8,7 @@ cp -R /home/builder/build/generated/packaging /home/builder/workspace
 
 # Install Adoptium Public Key
 sudo chmod 664 /etc/apk/repositories
+sudo chmod 775 /etc/apk/keys
 sudo chgrp abuild /etc/apk/repositories
 sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories

--- a/linux_new/jdk/alpine/src/main/packaging/entrypoint.sh
+++ b/linux_new/jdk/alpine/src/main/packaging/entrypoint.sh
@@ -14,6 +14,10 @@ sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifa
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories
 sudo wget -O /home/builder/.abuild/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 
+# As We Dont Build The Package Index We Dont Sign/Release It
+# This allows the build/test of the APK to succeed.
+export ABUILD_APK_INDEX_OPTS="--allow-untrusted"
+
 # Set permssions
 sudo chown -R builder /home/builder/out
 

--- a/linux_new/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/8/temurin-8-jdk.template.j2
@@ -21,7 +21,6 @@
 
 %if "%{vers_arch}" == "armv7hl"
 %define vers_arch arm
-%global upstream_version {{ upstreamarm32_version }}
 %endif
 
 %if "%{vers_arch}" == "x86_64"
@@ -94,6 +93,11 @@ Provides: jre-%{java_provides}-headless
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
 Source1: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
+
+# Reset Upstream Version Ahead Of Package Build
+%if "%{vers_arch}" == "arm"
+%global upstream_version {{ upstreamarm32_version }}
+%endif
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}

--- a/linux_new/jre/alpine/src/main/packaging/entrypoint.sh
+++ b/linux_new/jre/alpine/src/main/packaging/entrypoint.sh
@@ -8,6 +8,7 @@ cp -R /home/builder/build/generated/packaging /home/builder/workspace
 
 # Install Adoptium Public Key
 sudo chmod 664 /etc/apk/repositories
+sudo chmod 775 /etc/apk/keys
 sudo chgrp abuild /etc/apk/repositories
 sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories

--- a/linux_new/jre/alpine/src/main/packaging/entrypoint.sh
+++ b/linux_new/jre/alpine/src/main/packaging/entrypoint.sh
@@ -14,6 +14,10 @@ sudo wget -O /etc/apk/keys/adoptium.rsa.pub https://packages.adoptium.net/artifa
 sudo echo 'https://packages.adoptium.net/artifactory/apk/alpine/main' >> /etc/apk/repositories
 sudo wget -O /home/builder/.abuild/adoptium.rsa.pub https://packages.adoptium.net/artifactory/api/security/keypair/public/repositories/apk
 
+# As We Dont Build The Package Index We Dont Sign/Release It
+# This allows the build/test of the APK to succeed.
+export ABUILD_APK_INDEX_OPTS="--allow-untrusted"
+
 # Set permssions
 sudo chown -R builder /home/builder/out
 

--- a/linux_new/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/8/temurin-8-jre.template.j2
@@ -35,7 +35,6 @@ Prefix: /usr/lib/jvm/%{name}
 
 %if "%{vers_arch}" == "armv7hl"
 %define vers_arch arm
-%global upstream_version {{ upstreamarm32_version }}
 %endif
 
 %if "%{vers_arch}" == "x86_64"
@@ -76,6 +75,11 @@ Provides: jre-%{java_provides}-headless
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
 Source1: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
+
+# Reset Upstream Version Ahead Of Package Build
+%if "%{vers_arch}" == "arm"
+%global upstream_version {{ upstreamarm32_version }}
+%endif
 
 # Avoid build failures on some distros due to missing build-id in binaries.
 %global debug_package %{nil}


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS - I NEED TO MAKE A SMALL CHANGE TO THE JENKINS CONFIGURATION FOR THE NEW PACKAGE BUILD PROCESS - I'LL MERGE ONCE APPROVED SO I CAN COORDINATE THE EQUIVALENT CHANGE.

Update the SUSE templates to correct a bug introduced when downloading packages.  

Improve the permissions of the Alpine build to allow the use of the private key when validating  packages signed using the Adoptium private key.