### PR TITLE
Enabled MSI creation on windows_aarch64

### DIFF
--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -40,6 +40,11 @@ IF NOT DEFINED PRODUCT_UPDATE_INFO_LINK SET PRODUCT_UPDATE_INFO_LINK=https://ado
 IF NOT DEFINED WIX_HEAT_PATH SET WIX_HEAT_PATH=.\Resources\heat_dir\heat.exe
 IF NOT DEFINED WIX_VERSION SET WIX_VERSION=5.0.0
 
+REM default windows_SDK version
+REM See folder e.g. "C:\Program Files (x86)\Windows Kits\[10]\bin\[10.0.22621.0]\!PLATFORM!"
+IF NOT DEFINED WIN_SDK_MAJOR_VERSION SET WIN_SDK_MAJOR_VERSION=10
+IF NOT DEFINED WIN_SDK_FULL_VERSION SET WIN_SDK_FULL_VERSION=10.0.22621.0
+
 powershell -ExecutionPolicy Bypass -File "%~dp0\helpers\Validate-Input.ps1" ^
     -toValidate '%ARCH%' ^
     -validInputs "x64 x86-32 x86 arm64" ^
@@ -79,10 +84,6 @@ IF "%SKIP_MSI_VALIDATION%" == "true" (
 	SET "MSI_VALIDATION_OPTION= -sval "
 )
 
-REM Configure available SDK version:
-REM See folder e.g. "C:\Program Files (x86)\Windows Kits\[10]\bin\[10.0.16299.0]\x64"
-SET WIN_SDK_MAJOR_VERSION=10
-SET WIN_SDK_FULL_VERSION=10.0.22621.0
 SET WORKDIR=Workdir\
 mkdir %WORKDIR%
 

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -323,7 +323,7 @@ FOR %%A IN (%ARCH%) DO (
     )
 
     REM Add all supported languages to MSI Package attribute
-    CSCRIPT "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\x64\WiLangId.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi Package !LANGIDS!
+    CSCRIPT "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\!PLATFORM!\WiLangId.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi Package !LANGIDS!
     IF ERRORLEVEL 1 (
 		ECHO Failed to pack all languages into MSI : !LANGIDS!
 	    GOTO FAILED
@@ -355,7 +355,7 @@ FOR %%A IN (%ARCH%) DO (
 	        ECHO try !timestampErrors! / sha256 / timestamp server : %%s
 		REM Always hide password here
 		@ECHO OFF
-                "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\x64\signtool.exe" sign -f "%SIGNING_CERTIFICATE%" -p "%SIGN_PASSWORD%" -fd sha256 -d "Adoptium" -t %%s "ReleaseDir\!OUTPUT_BASE_FILENAME!.msi"
+                "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\!PLATFORM!\signtool.exe" sign -f "%SIGNING_CERTIFICATE%" -p "%SIGN_PASSWORD%" -fd sha256 -d "Adoptium" -t %%s "ReleaseDir\!OUTPUT_BASE_FILENAME!.msi"
 		@ECHO ON
 		IF NOT "%DEBUG%" == "true" @ECHO OFF
 

--- a/wix/BuildSetupTranslationTransform.cmd
+++ b/wix/BuildSetupTranslationTransform.cmd
@@ -42,7 +42,7 @@ IF ERRORLEVEL 1 (
     GOTO FAILED
 )
 
-cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\x64\WiLangId.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.msi Product %LANGID%
+cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\!PLATFORM!\WiLangId.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.msi Product %LANGID%
 IF ERRORLEVEL 1 (
     ECHO WiLangId failed with : %ERRORLEVEL%
     GOTO FAILED
@@ -53,12 +53,12 @@ IF ERRORLEVEL 1 (
     GOTO FAILED
 )
 ECHO.
-cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\x64\wisubstg.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.mst %LANGID%
+cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\!PLATFORM!\wisubstg.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.mst %LANGID%
 IF ERRORLEVEL 1 (
     ECHO wisubstg failed with : %ERRORLEVEL%
     GOTO FAILED
 )
-cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\x64\wisubstg.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi
+cscript "%ProgramFiles(x86)%\Windows Kits\%WIN_SDK_MAJOR_VERSION%\bin\%WIN_SDK_FULL_VERSION%\!PLATFORM!\wisubstg.vbs" //Nologo ReleaseDir\!OUTPUT_BASE_FILENAME!.msi
 
 del /Q "ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.msi"
 del /Q "ReleaseDir\!OUTPUT_BASE_FILENAME!.!CULTURE!.mst"

--- a/wix/README.md
+++ b/wix/README.md
@@ -59,11 +59,11 @@ call powershell.exe ./CreateSourceFolder.AdoptOpenJDK.ps1 ^
   set OUTPUT_BASE_FILENAME=%PRODUCT_SKU%%PRODUCT_MAJOR_VERSION%-%PRODUCT_CATEGORY%_%FOLDER_PLATFORM%_windows_%PACKAGE_TYPE%-%PRODUCT_FULL_VERSION%F
   ```
 
- `Build.OpenJDK_generic.cmd` statically depends on this SDK version (edit if needed):
+ `Build.OpenJDK_generic.cmd` depends on the windows SDK. The default version used is `10.0.22621.0`, but you can set the following variables if you have a different + compatible version installed:
 
   ```batch
   SET WIN_SDK_MAJOR_VERSION=10
-  SET WIN_SDK_FULL_VERSION=10.0.17763.0
+  SET WIN_SDK_FULL_VERSION=10.0.22621.0
   ```
 
 4. Run `Build.OpenJDK_generic.cmd` to create the MSI setup in "ReleaseDir":


### PR DESCRIPTION
Included in this change:
- allows for MSIs to be made on windows aarch64 machines
- enables users to use a nondefault windows SDK version as long as it is compatible and has the needed tools

This allows users to decouple windows_aarch64 MSI creation from needing windows_x64 machines and binaries for creation. 

Note: All original defaults are preserved.

I have tested these changes through the Microsoft build process, and I have tested the resulting installers to make sure that the same, expected behavior is observed.