### PR TITLE
Update JDK24 RPM installer templates

### DIFF
--- a/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -19,8 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname temurin-24-jdk
 
-Name:        temurin-24-jdk
+Name:        java-24-temurin-jdk
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JDK
@@ -80,6 +81,16 @@ Provides: java-sdk-24
 Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
+# Add Virtual Provide For Original Naming Format
+Provides: temurin-24-jdk
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so
+Provides: libjava.so
+Provides: libjvm.so
+Provides: libverify.so
+Provides: libjsig.so
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -109,9 +120,13 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{altname} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{altname}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
+ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{altname}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -199,6 +214,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+/usr/lib/jvm/temurin-24-jdk
+/usr/lib/jvm/%{altname}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -82,7 +82,7 @@ Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # Add Virtual Provide For Original Naming Format
-Provides: temurin-24-jdk
+Provides: %{altname}
 
 # Add Provides For Java Public Libraries
 Provides: libjawt.so
@@ -214,7 +214,6 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
-/usr/lib/jvm/temurin-24-jdk
 /usr/lib/jvm/%{altname}
 
 %changelog

--- a/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -82,7 +82,7 @@ Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
 # Add Virtual Provide For Original Naming Format
-Provides: temurin-24-jdk
+Provides: %{altname}
 
 # Add Provides For Java Public Libraries
 Provides: libjawt.so

--- a/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -19,8 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname temurin-24-jdk
 
-Name:        temurin-24-jdk
+Name:        java-24-temurin-jdk
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JDK
@@ -80,6 +81,16 @@ Provides: java-sdk-24
 Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
+# Add Virtual Provide For Original Naming Format
+Provides: temurin-24-jdk
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so
+Provides: libjava.so
+Provides: libjvm.so
+Provides: libverify.so
+Provides: libjsig.so
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -103,9 +114,13 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}%{_libdir}/jvm/%{altname} ]; then
+  rm -f %{buildroot}%{_libdir}/jvm/%{altname}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
+ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{altname}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -189,6 +204,7 @@ fi
 %files
 %defattr(-,root,root)
 %{prefix}
+%{_libdir}/jvm/%{altname}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -72,7 +72,7 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # Add Virtual Provide For Original Naming Format
-Provides: temurin-24-jre
+Provides: %{altname}
 
 # Add Provides For Java Public Libraries
 Provides: libjawt.so

--- a/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -19,8 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname temurin-24-jre
 
-Name:        temurin-24-jre
+Name:        java-24-temurin-jre
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JRE
@@ -70,6 +71,16 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provide For Original Naming Format
+Provides: temurin-24-jre
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so
+Provides: libjava.so
+Provides: libjvm.so
+Provides: libverify.so
+Provides: libjsig.so
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -99,9 +110,13 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{altname} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{altname}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
+ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{altname}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -134,6 +149,7 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+/usr/lib/jvm/%{altname}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -72,7 +72,7 @@ Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
 # Add Virtual Provide For Original Naming Format
-Provides: temurin-24-jre
+Provides: %{altname}
 
 # Add Provides For Java Public Libraries
 Provides: libjawt.so

--- a/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -19,8 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname temurin-24-jre
 
-Name:        temurin-24-jre
+Name:        java-24-temurin-jre
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JRE
@@ -70,6 +71,16 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provide For Original Naming Format
+Provides: temurin-24-jre
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so
+Provides: libjava.so
+Provides: libjvm.so
+Provides: libverify.so
+Provides: libjsig.so
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -93,9 +104,13 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}%{_libdir}/jvm/%{altname} ]; then
+  rm -f %{buildroot}%{_libdir}/jvm/%{altname}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
+ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{altname}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -124,6 +139,7 @@ fi
 %files
 %defattr(-,root,root)
 %{prefix}
+%{_libdir}/jvm/%{altname}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}


### PR DESCRIPTION
Update JDK24 installer templates for RPM ( RHEL & SUSE ) based distributions.

Fixes #1008

Also makes the required change for JDK24 ( see issue #1126 )

Changes the default package name to java-24-temurin-jdk, but also creates symlinks to the previous

`temurin-24-jre -> /usr/lib/jvm/java-24-temurin-jre`  
`temurin-24-jdk -> /usr/lib/jvm/java-24-temurin-jdk`  
`java-24-temurin-jdk`  
`java-24-temurin-jre`  
  
The new JDK/JRE package has this list of provides :  

JDK

```
rpm -q --provides java-24-temurin-jdk
java
java-24
java-24-devel
java-24-headless
java-24-openjdk
java-24-openjdk-devel
java-24-openjdk-headless
java-24-temurin-jdk = 24.0.0.0.0.36-0
java-24-temurin-jdk(x86-64) = 24.0.0.0.0.36-0
java-devel
java-devel-openjdk
java-headless
java-openjdk
java-openjdk-devel
java-openjdk-headless
java-sdk
java-sdk-24
java-sdk-24-openjdk
java-sdk-openjdk
libjava.so
libjawt.so
libjsig.so
libjverify.so
libjvm.so
temurin-24-jdk
```

JRE

```
rpm -q --provides java-24-temurin-jre

java-24-temurin-jre = 24.0.0.0.0.36-0
java-24-temurin-jre(x86-64) = 24.0.0.0.0.36-0
jre
jre-24
jre-24-headless
jre-24-openjre
jre-24-openjre-headless
jre-headless
jre-openjre
jre-openjre-headless
libjava.so
libjawt.so
libjsig.so
libjvm.so
libverify.so
temurin-24-jre
```