### PR TITLE
Remove redundant dirs from JDK24 Alpine build

### DIFF
--- a/linux_new/jdk/alpine/src/main/packaging/temurin/24/alpine.jdk24.template.j2
+++ b/linux_new/jdk/alpine/src/main/packaging/temurin/24/alpine.jdk24.template.j2
@@ -81,10 +81,8 @@ _jdk() {
 	mv "$_fromroot/bin"     "$_toroot"
 	mv "$_fromroot/conf"    "$_toroot"
 	mv "$_fromroot/include" "$_toroot"
-	mv "$_fromroot/jmods"   "$_toroot"
 	mv "$_fromroot/legal"   "$_toroot"
 	mv "$_fromroot/lib"     "$_toroot"
-	mv "$_fromroot/man"     "$_toroot"
 	mv "$_fromroot/release" "$_toroot"
 	mv "$_fromroot/NOTICE"  "$_toroot"
 


### PR DESCRIPTION
Fixes #1146 

There are 2 directories that have been removed from the Alpine JDK build ( the JRE never had these ) , the jmods and the man directories. The APKBuild template file needs amending to also remove these entries.