### PR TITLE
Improve rhel/suse globbing for new names.

### DIFF
--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -851,7 +851,6 @@ stage('Publish Packages') {
             def RHELarchitecture = ''
             def RHELDistro = "RPMS"
             def RHELPackFiles = findFiles(glob: "**/rhel/build/ospackage/t*.rpm") + findFiles(glob: "**/rhel/build/ospackage/j*.rpm")
-
             for (RHELPackFile in RHELPackFiles) {
                 RHELFileName = RHELPackFile.name
                 RHELFilePath = RHELPackFile.path


### PR DESCRIPTION
Since the rpm packages for jdk24 now follow openjdk naming standards the file globbing needs extending to cover java-24-temurin* ( whilst maintaining support for temurin-24-jdk* )