### PR TITLE
Update JDK24 RPM File Names To Be temurin-24 rather than java-24

### DIFF
--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -187,7 +187,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
         } else {
             echo "Target Doesnt Exist - Upload Files"
             // This Upload Works
-            // jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
+            jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
             break
         }
         case "Alpine":
@@ -199,7 +199,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             break
         } else {
             // This Upload Works
-            // jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
+            jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
             break
         }
         case "RPMS":
@@ -210,7 +210,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             echo "Target Exists - Skipping"
             break
         } else {
-            // jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
+            jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
             break
         }
         default:
@@ -909,10 +909,10 @@ post {
                 echo "Release : ${params.TAG}"
                 echo "FileName : ${ArchiveFileName}"
 
-                // build job: 'publish_linux_pkg_src', parameters: [
-                    // string(name: 'TAG', value: "${params.TAG}"),
-                    // string(name: 'FILENAME', value: "${ArchiveFileName}")
-                // ]
+                build job: 'publish_linux_pkg_src', parameters: [
+                    string(name: 'TAG', value: "${params.TAG}"),
+                    string(name: 'FILENAME', value: "${ArchiveFileName}")
+                ]
             } else {
                 echo 'Dry Run is enabled. Skipping downstream job trigger.'
             }

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -187,7 +187,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
         } else {
             echo "Target Doesnt Exist - Upload Files"
             // This Upload Works
-            jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
+            // jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
             break
         }
         case "Alpine":
@@ -199,7 +199,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             break
         } else {
             // This Upload Works
-            jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
+            // jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
             break
         }
         case "RPMS":
@@ -210,7 +210,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             echo "Target Exists - Skipping"
             break
         } else {
-            jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
+            // jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
             break
         }
         default:
@@ -909,10 +909,10 @@ post {
                 echo "Release : ${params.TAG}"
                 echo "FileName : ${ArchiveFileName}"
 
-                build job: 'publish_linux_pkg_src', parameters: [
-                    string(name: 'TAG', value: "${params.TAG}"),
-                    string(name: 'FILENAME', value: "${ArchiveFileName}")
-                ]
+                // build job: 'publish_linux_pkg_src', parameters: [
+                    // string(name: 'TAG', value: "${params.TAG}"),
+                    // string(name: 'FILENAME', value: "${ArchiveFileName}")
+                // ]
             } else {
                 echo 'Dry Run is enabled. Skipping downstream job trigger.'
             }

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -905,9 +905,9 @@ post {
     success {
         script {
             if (!params.DRY_RUN) {
-                  echo 'Build succeeded. Triggering downstream job...'
-                  echo "Release : ${params.TAG}"
-                  echo "FileName : ${ArchiveFileName}"
+                echo 'Build succeeded. Triggering downstream job...'
+                echo "Release : ${params.TAG}"
+                echo "FileName : ${ArchiveFileName}"
 
                 build job: 'publish_linux_pkg_src', parameters: [
                     string(name: 'TAG', value: "${params.TAG}"),

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -187,7 +187,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
         } else {
             echo "Target Doesnt Exist - Upload Files"
             // This Upload Works
-            // jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
+            jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
             break
         }
         case "Alpine":
@@ -199,7 +199,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             break
         } else {
             // This Upload Works
-            // jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
+            jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
             break
         }
         case "RPMS":
@@ -210,7 +210,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             echo "Target Exists - Skipping"
             break
         } else {
-            // jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
+            jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
             break
         }
         default:
@@ -906,13 +906,13 @@ post {
         script {
             if (!params.DRY_RUN) {
                   echo 'Build succeeded. Triggering downstream job...'
-//                echo "Release : ${params.TAG}"
-//                echo "FileName : ${ArchiveFileName}"
+                  echo "Release : ${params.TAG}"
+                  echo "FileName : ${ArchiveFileName}"
 
-                //build job: 'publish_linux_pkg_src', parameters: [
-                //    string(name: 'TAG', value: "${params.TAG}"),
-                //    string(name: 'FILENAME', value: "${ArchiveFileName}")
-                //]
+                build job: 'publish_linux_pkg_src', parameters: [
+                    string(name: 'TAG', value: "${params.TAG}"),
+                    string(name: 'FILENAME', value: "${ArchiveFileName}")
+                ]
             } else {
                 echo 'Dry Run is enabled. Skipping downstream job trigger.'
             }

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -187,7 +187,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
         } else {
             echo "Target Doesnt Exist - Upload Files"
             // This Upload Works
-            jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
+            // jf 'rt u ${FILENAME} deb/pool/main/t/temurin-${RELNUM}/ --target-props=${DISTROLIST}deb.component=main;deb.architecture=${BUILDARCH} --flat=true'
             break
         }
         case "Alpine":
@@ -199,7 +199,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             break
         } else {
             // This Upload Works
-            jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
+            // jf 'rt u **/build/ospackage/${FILENAME} apk/alpine/main/${BUILDARCH}/ --flat=true'
             break
         }
         case "RPMS":
@@ -210,7 +210,7 @@ def CheckAndUpload(String Target, String Distro, String BuildArch, String RelVer
             echo "Target Exists - Skipping"
             break
         } else {
-            jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
+            // jf 'rt u ${FILENAME} ${PACKAGEDIR}/ --flat=true'
             break
         }
         default:
@@ -905,14 +905,14 @@ post {
     success {
         script {
             if (!params.DRY_RUN) {
-                echo 'Build succeeded. Triggering downstream job...'
-                echo "Release : ${params.TAG}"
-                echo "FileName : ${ArchiveFileName}"
+                  echo 'Build succeeded. Triggering downstream job...'
+//                echo "Release : ${params.TAG}"
+//                echo "FileName : ${ArchiveFileName}"
 
-                build job: 'publish_linux_pkg_src', parameters: [
-                    string(name: 'TAG', value: "${params.TAG}"),
-                    string(name: 'FILENAME', value: "${ArchiveFileName}")
-                ]
+                //build job: 'publish_linux_pkg_src', parameters: [
+                //    string(name: 'TAG', value: "${params.TAG}"),
+                //    string(name: 'FILENAME', value: "${ArchiveFileName}")
+                //]
             } else {
                 echo 'Dry Run is enabled. Skipping downstream job trigger.'
             }

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -19,9 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
-%global altname temurin-24-jdk
+%global altname java-24-temurin-jdk
 
-Name:        java-24-temurin-jdk
+Name:        temurin-24-jdk
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JDK
@@ -33,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -81,7 +81,7 @@ Provides: java-sdk-24
 Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
-# Add Virtual Provide For Original Naming Format
+# Add Virtual Provides For Altname
 Provides: %{altname}
 
 # Add Provides For Java Public Libraries
@@ -120,13 +120,13 @@ popd
 # noop
 
 %install
-if [ -L %{buildroot}/usr/lib/jvm/%{altname} ]; then
-  rm -f %{buildroot}/usr/lib/jvm/%{altname}
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
 fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
-ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{altname}
+ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{name}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -214,7 +214,7 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
-/usr/lib/jvm/%{altname}
+/usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -84,6 +84,9 @@ Provides: java-sdk-%{java_provides}
 # Add Virtual Provides For Altname
 Provides: %{altname}
 
+# Obsolete JDK24 v0 package due to naming
+Obsoletes: java-24-temurin-jdk < 24.0.0.0.0.36-1
+
 # Add Provides For Java Public Libraries
 Provides: libjawt.so
 Provides: libjava.so

--- a/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -19,9 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
-%global altname temurin-24-jdk
+%global altname java-24-temurin-jdk
 
-Name:        java-24-temurin-jdk
+Name:        temurin-24-jdk
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JDK
@@ -33,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: %{_libdir}/jvm/%{name}
+Prefix: %{_libdir}/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -81,7 +81,7 @@ Provides: java-sdk-24
 Provides: java-sdk-24-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
-# Add Virtual Provide For Original Naming Format
+# Add Virtual Provides For Altname
 Provides: %{altname}
 
 # Add Provides For Java Public Libraries
@@ -114,13 +114,13 @@ popd
 # noop
 
 %install
-if [ -L %{buildroot}%{_libdir}/jvm/%{altname} ]; then
-  rm -f %{buildroot}%{_libdir}/jvm/%{altname}
+if [ -L %{buildroot}%{_libdir}/jvm/%{name} ]; then
+  rm -f %{buildroot}%{_libdir}/jvm/%{name}
 fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
-ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{altname}
+ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{name}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -204,7 +204,7 @@ fi
 %files
 %defattr(-,root,root)
 %{prefix}
-%{_libdir}/jvm/%{altname}
+%{_libdir}/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -84,6 +84,9 @@ Provides: java-sdk-%{java_provides}
 # Add Virtual Provides For Altname
 Provides: %{altname}
 
+# Obsolete JDK24 v0 package due to naming
+Obsoletes: java-24-temurin-jdk < 24.0.0.0.0.36-1
+
 # Add Provides For Java Public Libraries
 Provides: libjawt.so
 Provides: libjava.so

--- a/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -19,9 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
-%global altname temurin-24-jre
+%global altname java-24-temurin-jre
 
-Name:        java-24-temurin-jre
+Name:        temurin-24-jre
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JRE
@@ -33,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -71,7 +71,7 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
-# Add Virtual Provide For Original Naming Format
+# Add Virtual Provides For Altname
 Provides: %{altname}
 
 # Add Provides For Java Public Libraries
@@ -110,13 +110,13 @@ popd
 # noop
 
 %install
-if [ -L %{buildroot}/usr/lib/jvm/%{altname} ]; then
-  rm -f %{buildroot}/usr/lib/jvm/%{altname}
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
 fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
-ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{altname}
+ln -s %{prefix} %{buildroot}/usr/lib/jvm/%{name}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -149,7 +149,7 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
-/usr/lib/jvm/%{altname}
+/usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -74,6 +74,9 @@ Provides: jre-%{java_provides}-headless
 # Add Virtual Provides For Altname
 Provides: %{altname}
 
+# Obsolete JRE24 v0 package due to naming
+Obsoletes: java-24-temurin-jre < 24.0.0.0.0.36-1
+
 # Add Provides For Java Public Libraries
 Provides: libjawt.so
 Provides: libjava.so

--- a/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -19,9 +19,9 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
-%global altname temurin-24-jre
+%global altname java-24-temurin-jre
 
-Name:        java-24-temurin-jre
+Name:        temurin-24-jre
 Version:     %{spec_version}
 Release:     %{spec_release}
 Summary:     Eclipse Temurin 24 JRE
@@ -33,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: %{_libdir}/jvm/%{name}
+Prefix: %{_libdir}/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -71,7 +71,7 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
-# Add Virtual Provide For Original Naming Format
+# Add Virtual Provides For Altname
 Provides: %{altname}
 
 # Add Provides For Java Public Libraries
@@ -104,13 +104,13 @@ popd
 # noop
 
 %install
-if [ -L %{buildroot}%{_libdir}/jvm/%{altname} ]; then
-  rm -f %{buildroot}%{_libdir}/jvm/%{altname}
+if [ -L %{buildroot}%{_libdir}/jvm/%{name} ]; then
+  rm -f %{buildroot}%{_libdir}/jvm/%{name}
 fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
-ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{altname}
+ln -s %{prefix} %{buildroot}%{_libdir}/jvm/%{name}
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/lib/security/cacerts"
@@ -139,7 +139,7 @@ fi
 %files
 %defattr(-,root,root)
 %{prefix}
-%{_libdir}/jvm/%{altname}
+%{_libdir}/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -74,6 +74,9 @@ Provides: jre-%{java_provides}-headless
 # Add Virtual Provides For Altname
 Provides: %{altname}
 
+# Obsolete JRE24 v0 package due to naming
+Obsoletes: java-24-temurin-jre < 24.0.0.0.0.36-1
+
 # Add Provides For Java Public Libraries
 Provides: libjawt.so
 Provides: libjava.so


### PR DESCRIPTION
Following the PMC discussion, the decision was made to maintain the original temurin RPM file names, but continue to install to an SELinux compatible path, and allow symlinks and virtual provides to work for both new & old install locations and names.