### PR TITLE
Improve JDK24 RPM Provides

### DIFF
--- a/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -88,11 +88,11 @@ Provides: %{altname}
 Obsoletes: java-24-temurin-jdk < 24.0.0.0.0.36-1
 
 # Add Provides For Java Public Libraries
-Provides: libjawt.so
-Provides: libjava.so
-Provides: libjvm.so
-Provides: libverify.so
-Provides: libjsig.so
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
 
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
+++ b/linux_new/jdk/suse/src/main/packaging/temurin/24/temurin-24-jdk.template.j2
@@ -88,11 +88,11 @@ Provides: %{altname}
 Obsoletes: java-24-temurin-jdk < 24.0.0.0.0.36-1
 
 # Add Provides For Java Public Libraries
-Provides: libjawt.so
-Provides: libjava.so
-Provides: libjvm.so
-Provides: libverify.so
-Provides: libjsig.so
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
 
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -78,11 +78,11 @@ Provides: %{altname}
 Obsoletes: java-24-temurin-jre < 24.0.0.0.0.36-1
 
 # Add Provides For Java Public Libraries
-Provides: libjawt.so
-Provides: libjava.so
-Provides: libjvm.so
-Provides: libverify.so
-Provides: libjsig.so
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
 
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz

--- a/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
+++ b/linux_new/jre/suse/src/main/packaging/temurin/24/temurin-24-jre.template.j2
@@ -78,11 +78,11 @@ Provides: %{altname}
 Obsoletes: java-24-temurin-jre < 24.0.0.0.0.36-1
 
 # Add Provides For Java Public Libraries
-Provides: libjawt.so
-Provides: libjava.so
-Provides: libjvm.so
-Provides: libverify.so
-Provides: libjsig.so
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
 
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK24U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz


### PR DESCRIPTION
Fixes #1126  improve the specification of the public library provides, by including the system architecture flag.

Tested build with my local installer build process: [https://ci.adoptium.net/job/build-scripts/job/release/job/sfr-build-linux-package-modular/1025/console](https://ci.adoptium.net/job/build-scripts/job/release/job/sfr-build-linux-package-modular/1025/console)   
  
and package installs on local vms for Fedora 40, Centos 8 and OpenSuse.