### PR TITLE
MAC Pkgbuild Process : Exclude Jmods from PKG build

### DIFF
--- a/pkgbuild/Jenkinsfile
+++ b/pkgbuild/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         string(name: 'UPSTREAM_JOB_NUMBER', description: 'e.g. 123')
         string(name: 'CERTIFICATE', description: 'Certificate name to sign the installer')
         string(name: 'FILTER', defaultValue: '**/OpenJDK*_mac_*.tar.gz', description: 'e.g. **/OpenJDK*_mac_*.tar.gz')
+        string(name: 'EXCLUDES', defaultValue: '**/OpenJDK*jmods*_mac_*.tar.gz', description: 'Binary Excludes from pkgbuild e.g. OpenJDK*jmods*_mac_*.tar.gz')
         string(name: 'MAJOR_VERSION', description: 'e.g. 8')
         string(name: 'FULL_VERSION', description: 'e.g 1.8.0_192 or 11+28')
     }
@@ -25,7 +26,7 @@ pipeline {
         }
         stage('Copy Artifacts') {
             steps {
-                copyArtifacts filter: '${FILTER}', fingerprintArtifacts: true, projectName: '${UPSTREAM_JOB_NAME}', selector: specific('${UPSTREAM_JOB_NUMBER}')
+                copyArtifacts filter: '${FILTER}', excludes: '${EXCLUDES}', fingerprintArtifacts: true, projectName: '${UPSTREAM_JOB_NAME}', selector: specific('${UPSTREAM_JOB_NUMBER}')
             }
         }
         stage('Build Installer') {


### PR DESCRIPTION
Update the mac pkg build process to not build installer packages for the mac jmods archive.

Tested In Isolation Here: https://ci.adoptium.net/job/build-scripts/job/release/job/sfr-mac-installer/1/