### PR TITLE
Update Debian Installer Build For PPC64LE to use debian:bookworm docker image

### DIFF
--- a/linux_new/jdk/debian/build.gradle
+++ b/linux_new/jdk/debian/build.gradle
@@ -132,7 +132,7 @@ if ("$arch" == "ppc64el") {
 		project.exec {
 			workingDir "src/main/packaging"
 			commandLine "docker", "build", "--no-cache", "--pull",
-				"--build-arg", "IMAGE=ppc64le/debian:bullseye",
+				"--build-arg", "IMAGE=ppc64le/debian:bookworm",
 				"-t", "adoptium-packages-linux-jdk-debian",
 				"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 				"-f", "Dockerfile",

--- a/linux_new/jre/debian/build.gradle
+++ b/linux_new/jre/debian/build.gradle
@@ -144,7 +144,7 @@ task packageJreDebian {
 		project.exec {
 			workingDir "src/main/packaging"
 			commandLine "docker", "build", "--no-cache", "--pull",
-				"--build-arg", "IMAGE=ppc64le/debian:bullseye",
+				"--build-arg", "IMAGE=ppc64le/debian:bookworm",
 				"-t", "adoptium-packages-linux-jdk-debian",
 				"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 				"-f", "Dockerfile",


### PR DESCRIPTION
A number of debian:bullseye packages for PPC64le have been removed from the debian central repositories.

In order to fix this, the docker image version used for ppc64le needs to be bumped to debian:bookworm.
