### PR TITLE
Removed debian_buster from checkJdkDebian tests to restore expected behavior

### DIFF
--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -49,7 +49,6 @@ public class DebianFlavours implements ArgumentsProvider {
 				Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 				Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 				Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-				Arguments.of(containerRegistry + "debian", "buster"),   // Debian/10 (oldstable)
 				Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 				Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 				Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)


### PR DESCRIPTION
This PR implements option #2 described in this issue: https://github.com/adoptium/installer/issues/1218