### PR TITLE
Update Debian Installer Build For s390x & arm32 to use debian:bookworm docker image

### DIFF
--- a/linux_new/jdk/debian/build.gradle
+++ b/linux_new/jdk/debian/build.gradle
@@ -108,7 +108,7 @@ if ("$arch" == "armhf") {
 		project.exec {
 			workingDir "src/main/packaging"
 			commandLine "docker", "build", "--no-cache", "--pull",
-				"--build-arg", "IMAGE=arm32v7/debian:bullseye",
+				"--build-arg", "IMAGE=arm32v7/debian:bookworm",
 				"-t", "adoptium-packages-linux-jdk-debian",
 				"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 				"-f", "Dockerfile",

--- a/linux_new/jdk/debian/build.gradle
+++ b/linux_new/jdk/debian/build.gradle
@@ -144,7 +144,7 @@ if ("$arch" == "s390x") {
 		project.exec {
 			workingDir "src/main/packaging"
 			commandLine "docker", "build", "--no-cache", "--pull",
-				"--build-arg", "IMAGE=s390x/debian:bullseye",
+				"--build-arg", "IMAGE=s390x/debian:bookworm",
 				"-t", "adoptium-packages-linux-jdk-debian",
 				"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 				"-f", "Dockerfile",

--- a/linux_new/jre/debian/build.gradle
+++ b/linux_new/jre/debian/build.gradle
@@ -108,7 +108,7 @@ task packageJreDebian {
 				project.exec {
 					workingDir "src/main/packaging"
 					commandLine "docker", "build", "--no-cache", "--pull",
-						"--build-arg", "IMAGE=arm32v7/debian:bullseye",
+						"--build-arg", "IMAGE=arm32v7/debian:bookworm",
 						"-t", "adoptium-packages-linux-jdk-debian",
 						"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 						"-f", "Dockerfile",
@@ -132,7 +132,7 @@ task packageJreDebian {
 				project.exec {
 					workingDir "src/main/packaging"
 					commandLine "docker", "build", "--no-cache", "--pull",
-						"--build-arg", "IMAGE=s390x/debian:bullseye",
+						"--build-arg", "IMAGE=s390x/debian:bookworm",
 						"-t", "adoptium-packages-linux-jdk-debian",
 						"--build-arg=CONTAINER_REGISTRY=${containerRegistry}",
 						"-f", "Dockerfile",


### PR DESCRIPTION
See #1216 

Same fix is now required for s390x & arm32..