### PR TITLE
Backport RHEL SELinux Fixes For JDK/JRE

### DIFF
--- a/linux_new/jdk/rhel/src/main/packaging/temurin/11/temurin-11-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/11/temurin-11-jdk.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-11-temurin-jdk
 
 Name:        temurin-11-jdk
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -88,6 +89,19 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK11 v0 package due to naming change
+Obsoletes: temurin-11-jdk < 11.0.28.0.0.6-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -117,6 +131,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -201,6 +218,14 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -211,6 +236,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/17/temurin-17-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/17/temurin-17-jdk.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-17-temurin-jdk
 
 Name:        temurin-17-jdk
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -88,6 +89,19 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK17 v0 package due to naming change
+Obsoletes: temurin-17-jdk < 17.0.16.0.0.8-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -117,6 +131,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -198,6 +215,14 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -208,6 +233,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/21/temurin-21-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/21/temurin-21-jdk.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-21-temurin-jdk
 
 Name:        temurin-21-jdk
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -80,6 +81,19 @@ Provides: java-sdk-21
 Provides: java-sdk-21-%{java_provides}
 Provides: java-sdk-%{java_provides}
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK21 v0 package due to naming change
+Obsoletes: temurin-21-jdk < 21.0.8.0.0.9-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -109,6 +123,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -189,6 +206,14 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/serialver.1 serialver.1 %{prefix}/man/man1/serialver.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -199,6 +224,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jdk/rhel/src/main/packaging/temurin/8/temurin-8-jdk.template.j2
+++ b/linux_new/jdk/rhel/src/main/packaging/temurin/8/temurin-8-jdk.template.j2
@@ -20,6 +20,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-8-temurin-jdk
 
 Name:        temurin-8-jdk
 Version:     %{spec_version}
@@ -33,7 +34,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -92,6 +93,19 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK8 v0 package due to naming change
+Obsoletes: temurin-8-jdk < 8.0.462.0.0.8-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
 Source1: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jdk_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
@@ -127,12 +141,12 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
-
-# Strip bundled Freetype and use OS package instead.
-rm -f "%{buildroot}%{prefix}/lib/libfreetype.so"
 
 # Use cacerts included in OS
 rm -f "%{buildroot}%{prefix}/jre/lib/security/cacerts"
@@ -237,6 +251,14 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_mandir}/man1/xjc.1 xjc.1 %{prefix}/man/man1/xjc.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -247,6 +269,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/11/temurin-11-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/11/temurin-11-jre.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-11-temurin-jre
 
 Name:        temurin-11-jre
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -70,6 +71,19 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK11 v0 package due to naming change
+Obsoletes: temurin-11-jre < 11.0.28.0.0.6-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK11U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -99,6 +113,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -137,6 +154,14 @@ if [ $1 -ge 1 ] ; then
                         --slave  %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -146,6 +171,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/17/temurin-17-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/17/temurin-17-jre.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-17-temurin-jre
 
 Name:        temurin-17-jre
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -70,6 +71,20 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK17 v0 package due to naming change
+Obsoletes: temurin-17-jre < 17.0.16.0.0.8-1
+
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK17U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -99,6 +114,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -124,6 +142,14 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -133,6 +159,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/21/temurin-21-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/21/temurin-21-jre.template.j2
@@ -19,6 +19,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-21-temurin-jre
 
 Name:        temurin-21-jre
 Version:     %{spec_version}
@@ -32,7 +33,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -70,6 +71,20 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JRE21 v0 package due to naming change
+Obsoletes: temurin-21-jre < 21.0.8.0.0.9-1
+
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz
 Source1: %{source_url_base}/jdk-%{upstream_version_url}/OpenJDK21U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_plus}.tar.gz.sha256.txt
@@ -99,6 +114,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -125,6 +143,14 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_bindir}/rmiregistry rmiregistry %{prefix}/bin/rmiregistry
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -134,6 +160,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}

--- a/linux_new/jre/rhel/src/main/packaging/temurin/8/temurin-8-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/8/temurin-8-jre.template.j2
@@ -18,6 +18,7 @@
 %global vers_arch {{ hardware_architecture }}
 %global src_num 0
 %global sha_src_num 1
+%global altname java-8-temurin-jre
 
 Name:        temurin-8-jre
 Version:     %{spec_version}
@@ -31,7 +32,7 @@ URL:         https://projects.eclipse.org/projects/adoptium
 Packager:    Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org>
 
 AutoReqProv: no
-Prefix: /usr/lib/jvm/%{name}
+Prefix: /usr/lib/jvm/%{altname}
 
 ExclusiveArch: {{ hardware_architecture }}
 
@@ -72,6 +73,19 @@ Provides: jre-headless
 Provides: jre-%{java_provides}
 Provides: jre-%{java_provides}-headless
 
+# Add Virtual Provides For Altname
+Provides: %{altname}
+
+# Obsolete Previous JDK8 v0 package due to naming change
+Obsoletes: temurin-8-jre < 8.0.462.0.0.8-1
+
+# Add Provides For Java Public Libraries
+Provides: libjawt.so%{?_isa}
+Provides: libjvm.so%{?_isa}
+Provides: libjava.so%{?_isa}
+Provides: libverify.so%{?_isa}
+Provides: libjsig.so%{?_isa}
+
 # First architecture ({{ hardware_architecture }})
 Source0: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz
 Source1: %{source_url_base}/jdk%{upstream_version}/OpenJDK8U-jre_%{vers_arch}_linux_hotspot_%{upstream_version_no_dash}.tar.gz.sha256.txt
@@ -107,6 +121,9 @@ popd
 # noop
 
 %install
+if [ -L %{buildroot}/usr/lib/jvm/%{name} ]; then
+  rm -f %{buildroot}/usr/lib/jvm/%{name}
+fi
 mkdir -p %{buildroot}%{prefix}
 cd %{buildroot}%{prefix}
 tar --strip-components=1 -C "%{buildroot}%{prefix}" -xf %{expand:%{SOURCE%{src_num}}}
@@ -150,6 +167,14 @@ if [ $1 -ge 1 ] ; then
                         --slave %{_mandir}/man1/unpack200.1 unpack200.1 %{prefix}/man/man1/unpack200.1
 fi
 
+%posttrans
+# Ensure compatibility path points to the new prefix after upgrade
+if [ -e /usr/lib/jvm/%{name} ] && [ ! -L /usr/lib/jvm/%{name} ]; then
+    # If a (now empty) directory remains, try to remove it
+    rmdir /usr/lib/jvm/%{name} >/dev/null 2>&1 || true
+fi
+ln -sfn %{prefix} /usr/lib/jvm/%{name}
+
 %preun
 if [ $1 -eq 0 ]; then
     update-alternatives --remove java %{prefix}/bin/java
@@ -159,6 +184,8 @@ fi
 %defattr(-,root,root)
 %{prefix}
 /usr/lib/tmpfiles.d/%{name}.conf
+# Ghost The Symlink to avoid conflicts
+%ghost /usr/lib/jvm/%{name}
 
 %changelog
 * {{ current_date }} Eclipse Adoptium Package Maintainers <temurin-dev@eclipse.org> {{ package_version }}-{{ package_release_version }}


### PR DESCRIPTION
Fixes #1171 

Backport of SELinux required changes to install to SELinux java/compliant path. 

Originally put into JDK24 as part of #1008 

These changes are not required for Suse/OpenSuse based O/S packages, as they do not use SELinux ( they use apparmor ) which is controlled differently to the Fedora/RHEL based O/Ss.

Testing strategy and results can be seen in #1171 
