### PR TITLE
Completely removed support for Ubuntu:Oracular due to eol failures

### DIFF
--- a/docs/Guide_To_The_Linux_Installers.md
+++ b/docs/Guide_To_The_Linux_Installers.md
@@ -45,7 +45,7 @@ Supported Linux Distros:
 Distribution Type| Supported Versions
 ----------|---------
 Apk (Alpine)| All supported version.
-Deb (Debian)| Trixie (Debian 13)<br>Bookworm (Debian 12)</br>Bullseye (Debian 11)<br>Oracular (Ubuntu 24.10)</br>Noble (Ubuntu 24.04)</br>Jammy (Ubuntu 22.04)</br>Focal (Ubuntu 20.04)</br>Bionic (Ubuntu 18.04)
+Deb (Debian)| Trixie (Debian 13)<br>Bookworm (Debian 12)</br>Bullseye (Debian 11)<br>Noble (Ubuntu 24.04)</br>Jammy (Ubuntu 22.04)</br>Focal (Ubuntu 20.04)</br>Bionic (Ubuntu 18.04)
 RPM (RHEL)| centos 7</br> rocky 8</br>RHEL7 , RHEL8 & RHEL9</br> Fedora 35, 36, 37, 38 ,39 , 40</br>Oracle Linux 7 & 8</br>Amazon Linux 2
 RPM(SUSE) | Opensuse 15.3</br>Opensuse 15.4</br>Opensuse 15.5</br>SLES 12</br>SLES15
 
@@ -430,7 +430,6 @@ For Debian based distributions a similar process is required, firstly add the di
             "bookworm", // Debian/12
             "bullseye", // Debian/11
             "buster",   // Debian/10
-            "oracular", // Ubuntu/24.10 (STS)
             "noble",    // Ubuntu/24.04 (LTS)
             "jammy",    // Ubuntu/22.04 (LTS)
             "focal",    // Ubuntu/20.04 (LTS)
@@ -448,7 +447,7 @@ In addition to the updates detailed above, it is also important to change the fo
 the following line should be changed :
 
 ```
-debVersionList="trixie bookworm bullseye oracular noble jammy focal bionic"
+debVersionList="trixie bookworm bullseye noble jammy focal bionic"
 ```
 
 And similarly in the following two files
@@ -464,7 +463,6 @@ The array needs to be updated to add or remove distributions as necessary as sho
        	  Arguments.of("debian", "trixie"),   // Debian/13 (testing)
           Arguments.of("debian", "bookworm"), // Debian/12 (testing)
           Arguments.of("debian", "bullseye"), // Debian/11 (stable)
-          Arguments.of("ubuntu", "oracular"), // Ubuntu/24.10 (STS)
           Arguments.of("ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
           Arguments.of("ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
           Arguments.of("ubuntu", "focal"),    // Ubuntu/20.04 (LTS)

--- a/linux/README.md
+++ b/linux/README.md
@@ -201,7 +201,6 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 |------------------------------|:----------------------:|:----:|
 | debian/12 (bookworm/testing) |         x86_64         |      |
 | debian/11 (bullseye/stable)  |         x86_64         |      |
-| ubuntu/24.10 (oracular)      |         x86_64         |      |
 | ubuntu/24.04 (noble)         |         x86_64         |      |
 | ubuntu/22.04 (jammy)         |         x86_64         |      |
 | ubuntu/20.04 (focal)         |         x86_64         |      |

--- a/linux/ca-certificates/debian/build.gradle
+++ b/linux/ca-certificates/debian/build.gradle
@@ -28,7 +28,6 @@ def deb_versions = [
 		"trixie", // Debian/13
 		"bookworm", // Debian/12
 		"bullseye", // Debian/11
-		"oracular", // Ubuntu/24.10 (STS)
 		"noble",    // Ubuntu/24.04 (LTS)
 		"jammy",    // Ubuntu/22.04 (LTS)
 		"focal",    // Ubuntu/20.04 (LTS)

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/ChangesVerificationTest.java
@@ -32,10 +32,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChangesVerificationTest {
 
 	private static String[] versionsList = {
-		  "trixie", // Debian/13
+		    "trixie",   // Debian/13
 			"bookworm", // Debian/12
 			"bullseye", // Debian/11
-			"oracular", // Ubuntu/24.10 (STS)
 			"noble",    // Ubuntu/24.04 (LTS)
 			"jammy",    // Ubuntu/22.04 (LTS)
 			"focal",    // Ubuntu/20.04 (LTS)

--- a/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
+++ b/linux/ca-certificates/debian/src/packageTest/java/org/adoptium/cacertificates/DebianFlavours.java
@@ -48,7 +48,6 @@ public class DebianFlavours implements ArgumentsProvider {
 		  	Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 			Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 			Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-			Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 			Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "focal"),    // Ubuntu/20.04 (LTS)

--- a/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -49,7 +49,6 @@ public class DebianFlavours implements ArgumentsProvider {
 				Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 				Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 				Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-				Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 				Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 				Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 				Arguments.of(containerRegistry + "ubuntu", "focal"),    // Ubuntu/20.04 (LTS)

--- a/linux/jre/debian/src/main/packaging/build.sh
+++ b/linux/jre/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="trixie bookworm bullseye oracular noble jammy focal bionic"
+debVersionList="trixie bookworm bullseye noble jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -49,7 +49,6 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 			Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 			Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-			Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 			Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "focal"),    // Ubuntu/20.04 (LTS)

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -25,7 +25,6 @@ def deb_distros = [
 "bookworm", // Debian/12
 "bullseye", // Debian/11
 "buster",   // Debian/10
-"oracular", // Ubuntu/24.10 (STS)
 "noble",    // Ubuntu/24.04 (LTS)
 "jammy",    // Ubuntu/22.04 (LTS)
 "focal",    // Ubuntu/20.04 (LTS)

--- a/linux_new/README.md
+++ b/linux_new/README.md
@@ -202,7 +202,6 @@ Supported platform amd64, arm64, armhf, ppc64le, s390x (s390x is only available 
 | debian/13 (trixie/testing)   |         x86_64         |      |
 | debian/12 (bookworm/testing) |         x86_64         |      |
 | debian/11 (bullseye/stable)  |         x86_64         |      |
-| ubuntu/24.10 (oracular)      |         x86_64         |      |
 | ubuntu/24.04 (noble)         |         x86_64         |      |
 | ubuntu/22.04 (jammy)         |         x86_64         |      |
 | ubuntu/20.04 (focal)         |         x86_64         |      |

--- a/linux_new/jdk/debian/src/main/packaging/build.sh
+++ b/linux_new/jdk/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="trixie bookworm bullseye oracular noble jammy focal bionic"
+debVersionList="trixie bookworm bullseye noble jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux_new/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux_new/jdk/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -49,7 +49,6 @@ public class DebianFlavours implements ArgumentsProvider {
 				Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 				Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 				Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-				Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 				Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 				Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 				Arguments.of(containerRegistry + "ubuntu", "focal"),    // Ubuntu/20.04 (LTS)

--- a/linux_new/jre/debian/src/main/packaging/build.sh
+++ b/linux_new/jre/debian/src/main/packaging/build.sh
@@ -27,7 +27,7 @@ if [ "$buildLocalFlag" == "true" ]; then
 fi
 
 # $ and $ARCH are env variables passing in from "docker run"
-debVersionList="trixie bookworm bullseye oracular noble jammy focal bionic"
+debVersionList="trixie bookworm bullseye noble jammy focal bionic"
 
 # the target package is only based on the host machine's ARCH
 # ${buildArch} is only used for debug purpose what really matter is the label on the jenkins agent

--- a/linux_new/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
+++ b/linux_new/jre/debian/src/packageTest/java/packaging/DebianFlavours.java
@@ -49,7 +49,6 @@ public class DebianFlavours implements ArgumentsProvider {
 			Arguments.of(containerRegistry + "debian", "trixie"),   // Debian/13 (testing)
 			Arguments.of(containerRegistry + "debian", "bookworm"), // Debian/12 (testing)
 			Arguments.of(containerRegistry + "debian", "bullseye"), // Debian/11 (stable)
-			Arguments.of(containerRegistry + "ubuntu", "oracular"), // Ubuntu/24.10 (STS)
 			Arguments.of(containerRegistry + "ubuntu", "noble"),    // Ubuntu/24.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "jammy"),    // Ubuntu/22.04 (LTS)
 			Arguments.of(containerRegistry + "ubuntu", "focal"),    // Ubuntu/20.04 (LTS)


### PR DESCRIPTION
Looks like this issue came up again. This PR fixes the installer tool in the same way that I fixed it when debian:buster went eol. Used my other PR as a template: https://github.com/adoptium/installer/pull/1220