### PR TITLE
Improve packages cask installation in the GitHubAction for testing MacOS

### DIFF
--- a/.github/workflows/pkgbuild.yml
+++ b/.github/workflows/pkgbuild.yml
@@ -26,7 +26,9 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install dependencies
-      run: brew install --cask packages
+      run: | 
+        brew update
+        brew install --cask packages
 
     - name: Fetch latest macOS version from Adoptium API
       run: |


### PR DESCRIPTION
Fixes #1329 

Updated the macos packages cask install  step to include a brew update, to ensure the latest cask versions are being installed.