### PR TITLE
Add Housekeeping step to artifact publish job.

### DIFF
--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -977,11 +977,11 @@ stage('Publish Packages') {
     }
 // Publish Packages Stage - End
 // Housekeeping Step
-post {
-  always {
-    cleanWs(deleteDirs: true, disableDeferredWipeout: true)
-  }
-}
+    post {
+      always {
+        cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+      }
+    }
 // End Housekeeping
   }
 // Stage Definition - End


### PR DESCRIPTION
Fixes #1338 

Add a housekeeping step, to remove retrieved artifacts, once published. Reruns of this job, would pull the artifacts down again.

This should avoid the issue on dynamic agents, whereby re-use can cause artifacts to be inadvertently uploaded to the wrong path.

Also correct an errant "," in the debian check and upload process.

Tested with the corrections : https://ci.adoptium.net/job/build-scripts/job/release/job/sfr-build-linux-package-modular/1159/