### PR TITLE
Forcibly remove headful library files in headless JRE 26

### DIFF
--- a/linux_new/jre/rhel/src/main/packaging/temurin/26/temurin-26-jre.template.j2
+++ b/linux_new/jre/rhel/src/main/packaging/temurin/26/temurin-26-jre.template.j2
@@ -155,7 +155,7 @@ echo "This is the headful version, nothing will be removed"
 %else
 echo "This is the headless version, headful libraries will be removed"
 pushd "%{buildroot}%{prefix}/lib"
- rm -v libsplashscreen.so libawt_xawt.so libjawt.so
+ rm -vf libsplashscreen.so libawt_xawt.so libjawt.so
 popd
 %endif
 


### PR DESCRIPTION
These library files wont be present in headless installer builds, so the `-f` should cover both cases (when the files are and aren't present)