### PR TITLE
Add packages for Fedora Linux 44

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -592,6 +592,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch, String Version) {
             'rpm/fedora/41',
             'rpm/fedora/42',
             'rpm/fedora/43',
+            'rpm/fedora/44',
             'rpm/fedora/rawhide',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -49,6 +49,7 @@ def rhel_distros = [
     'rpm/fedora/41',
     'rpm/fedora/42',
     'rpm/fedora/43',
+    'rpm/fedora/44',
     'rpm/fedora/rawhide',
     'rpm/oraclelinux/7',
     'rpm/oraclelinux/8',


### PR DESCRIPTION
Fedora Linux 44 Beta has been released on [March 10th](https://fedoramagazine.org/announcing-fedora-linux-44-beta/). Fedora Linux 44 will probably release fully in a week (April 28th).

This pr updates the jenkinsfiles to also build packages for Fedora Linux 44