### PR TITLE
Update alpine test images & testContainer dependency

### DIFF
--- a/linux_new/jdk/alpine/build.gradle
+++ b/linux_new/jdk/alpine/build.gradle
@@ -6,7 +6,7 @@ import org.gradle.process.ExecOperations
 
 ext {
 	junitVersion = "6.0.3"
-	testcontainersVersion = "1.20.3"
+	testcontainersVersion = "1.21.4"
 	assertjCoreVersion = "3.26.3"
 }
 

--- a/linux_new/jdk/alpine/src/packageTest/java/packaging/AlpineFlavours.java
+++ b/linux_new/jdk/alpine/src/packageTest/java/packaging/AlpineFlavours.java
@@ -32,7 +32,7 @@ public class AlpineFlavours implements ArgumentsProvider {
 		 * Alpine policy: current (alive) releases and development version.
 		 *     (https://alpinelinux.org/releases/)
 		 */
-		
+
 		String containerRegistry = "";
 
 		if (System.getenv("containerRegistry") == null) {
@@ -45,9 +45,9 @@ public class AlpineFlavours implements ArgumentsProvider {
 		return Stream.of(
 			Arguments.of(containerRegistry + "alpine", "edge"),
 			Arguments.of(containerRegistry + "alpine", "latest"),
-			Arguments.of(containerRegistry + "alpine", "3.19"),
-			Arguments.of(containerRegistry + "alpine", "3.18"),
-			Arguments.of(containerRegistry + "alpine", "3.17")
+			Arguments.of(containerRegistry + "alpine", "3.21"),
+			Arguments.of(containerRegistry + "alpine", "3.22"),
+			Arguments.of(containerRegistry + "alpine", "3.23")
 		);
 	}
 }

--- a/linux_new/jre/alpine/build.gradle
+++ b/linux_new/jre/alpine/build.gradle
@@ -6,7 +6,7 @@ import org.gradle.process.ExecOperations
 
 ext {
 	junitVersion = "6.0.3"
-	testcontainersVersion = "1.20.3"
+	testcontainersVersion = "1.21.4"
 	assertjCoreVersion = "3.26.3"
 }
 


### PR DESCRIPTION
Fixes #1392 

Update the alpine test images used by the package tests to the current alpine supported versions.

In addition bump the Junit TestContainers to the latest version, that supports the current version of the docker engine.

Tested Locally OK, and also tested in the automated package production test harness..

https://ci.adoptium.net/job/build-scripts/job/release/job/sfr-build-linux-package-modular/1307/

