### PR TITLE
Add oracle linux 9 & 10 to installer publishes.

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -597,6 +597,8 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch, String Version) {
             'rpm/fedora/rawhide',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',
+            'rpm/oraclelinux/9',
+            'rpm/oraclelinux/10',
             'rpm/amazonlinux/2'
         ],
         'suse'   : [

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -54,6 +54,8 @@ def rhel_distros = [
     'rpm/fedora/rawhide',
     'rpm/oraclelinux/7',
     'rpm/oraclelinux/8',
+    'rpm/oraclelinux/9',
+    'rpm/oraclelinux/10',
     'rpm/amazonlinux/2'
     ]
 


### PR DESCRIPTION
Fixes #1439 

Adds Oracle Linux 9 & 10 versions to the RPM package publishing matrix.
