### PR TITLE
Add packages for Fedora Linux 45

### DIFF
--- a/linux/Jenkinsfile
+++ b/linux/Jenkinsfile
@@ -594,6 +594,7 @@ def uploadRpmArtifacts(String DISTRO, String rpmArch, String Version) {
             'rpm/fedora/42',
             'rpm/fedora/43',
             'rpm/fedora/44',
+            'rpm/fedora/45',
             'rpm/fedora/rawhide',
             'rpm/oraclelinux/7',
             'rpm/oraclelinux/8',

--- a/linux_new/Jenkinsfile
+++ b/linux_new/Jenkinsfile
@@ -51,6 +51,7 @@ def rhel_distros = [
     'rpm/fedora/42',
     'rpm/fedora/43',
     'rpm/fedora/44',
+    'rpm/fedora/45',
     'rpm/fedora/rawhide',
     'rpm/oraclelinux/7',
     'rpm/oraclelinux/8',


### PR DESCRIPTION
Previous upgrade: #1391 

According to the [Fedora Linux 45 Schedule](https://fedorapeople.org/groups/schedule/f-45/f-45-all-tasks.html), the 45 branch was created from Rawhide on August 11th. That means that people can already upgrade to Fedora Linux 45 by dnf upgrade, even though the beta has not yet been released.